### PR TITLE
docs: Add project-global README for contributing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Telegram Bot API typings for Flow, TypeScript and Rust
+
+This repository contains [Telegram Bot API](https://core.telegram.org/bots/api) typings for [Flow](https://flow.org/), [TypeScript](https://www.typescriptlang.org/) and [Rust](https://www.rust-lang.org/).
+
+The types are automatically generated for all supported languages from the Telegram Bot API website.
+
+## Flow and TypeScript typings
+
+See [javascript/](javascript/) folder.
+
+## Rust typings
+
+See [rust](rust/) folder.
+
+## Contributing
+
+Source code for the type generation lives under [lib/](lib/) folder.
+
+### Setting up local development environment
+
+To contribute to this project, you will need to have the following tools installed:
+
+* Rust
+* Node v8.x or higher
+* npm v5.7.1 or higher
+
+Once these tools are installed, you can install the required dependencies:
+
+```
+npm install
+cargo install rustfmt --version 0.9.0
+```
+
+### Generating new typings
+
+To generate new types, run the following:
+
+```
+npm run build
+```
+
+If the [Telegram Bot API](https://core.telegram.org/bots/api) documentation has not changed, and you haven't done any changes to code, you should not get any diff.


### PR DESCRIPTION
I haven't done much work with Rust before so having to install rustfmt was a new thing for me. I figured it might help others with contributing to outline the steps I had to go through to figure out how I can get this project to run locally.

I wanted to test out if I could even get started on #2 as I'd really like my `sendMessage` function to be typesafe in my new project :grin: