### PR TITLE
fix: Bug in parser, breaking type generation

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -205,7 +205,7 @@ async function requestAndParse(store/*: Store*/) {
 
     let typeClass
 
-    if (['Field', 'Parameters'].includes(type)) {
+    if (!['Field', 'Parameters'].includes(type)) {
       continue // eslint-disable-line no-continue
     }
 


### PR DESCRIPTION
I accidentally caused a bug in f42d8730c7015d45b68bd9871c5850ead7ef90be
when doing https://github.com/sergeysova/telegram-typings/pull/18 which
caused type generation to be broken