### PR TITLE
Little patch to make parsing of methods work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ Cargo.lock
 **/*.rs.bk
 
 # End of https://www.gitignore.io/api/rust
+
+# Ignore personal .vscode configuration
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-  "javascript.validate.enable": false,
-  "typescript.validate.enable": false,
-  "flow.enabled": true,
-  "flow.useNPMPackagedFlow": true,
-  "flow.stopFlowOnExit": true,
-  "flow.runOnAllFiles": true,
-  "workbench.colorTheme": "Atom One Dark"
-}

--- a/javascript/index.d.ts
+++ b/javascript/index.d.ts
@@ -17,27 +17,128 @@ export interface InputFile {}
  */
 export interface PassportData {
   /**
-  
+   * Array with information about documents and other Telegram Passport 
+   * elements that was shared with the bot
    */
   data: EncryptedPassportElement[];
 
   /**
-  
+   * Encrypted credentials required to decrypt the data
    */
   credentials: EncryptedCredentials;
 }
 
 /**
-
+ * Contains information about documents or other Telegram Passport elements 
+ * shared with the bot by the user.
  */
-export interface EncryptedPassportElement {}
+export interface EncryptedPassportElement {
+  /**
+   * Element type. One of “personal_details”, “passport”, “driver_license”, 
+   * “identity_card”, “internal_passport”, “address”, “utility_bill”, 
+   * “bank_statement”, “rental_agreement”, “passport_registration”, 
+   * “temporary_registration”, “phone_number”, “email”.
+   */
+  type: string;
+
+  /**
+   * Base64-encoded encrypted Telegram Passport element data provided by the 
+   * user, available for “personal_details”, “passport”, “driver_license”, 
+   * “identity_card”, “internal_passport” and “address” types. Can be 
+   * decrypted and verified using the accompanying EncryptedCredentials.
+   * @see https://core.telegram.org/bots/api#encryptedcredentials
+   */
+  data?: string;
+
+  /**
+   * User's verified phone number, available only for “phone_number” type
+   */
+  phone_number?: string;
+
+  /**
+   * User's verified email address, available only for “email” type
+   */
+  email?: string;
+
+  /**
+   * Array of encrypted files with documents provided by the user, available 
+   * for “utility_bill”, “bank_statement”, “rental_agreement”, 
+   * “passport_registration” and “temporary_registration” types. Files can be 
+   * decrypted and verified using the accompanying EncryptedCredentials.
+   * @see https://core.telegram.org/bots/api#encryptedcredentials
+   */
+  files?: PassportFile[];
+
+  /**
+   * Encrypted file with the front side of the document, provided by the 
+   * user. Available for “passport”, “driver_license”, “identity_card” and 
+   * “internal_passport”. The file can be decrypted and verified using the 
+   * accompanying EncryptedCredentials.
+   * @see https://core.telegram.org/bots/api#encryptedcredentials
+   */
+  front_side?: PassportFile;
+
+  /**
+   * Encrypted file with the reverse side of the document, provided by the 
+   * user. Available for “driver_license” and “identity_card”. The file can 
+   * be decrypted and verified using the accompanying EncryptedCredentials.
+   * @see https://core.telegram.org/bots/api#encryptedcredentials
+   */
+  reverse_side?: PassportFile;
+
+  /**
+   * Encrypted file with the selfie of the user holding a document, provided 
+   * by the user; available for “passport”, “driver_license”, “identity_card” 
+   * and “internal_passport”. The file can be decrypted and verified using 
+   * the accompanying EncryptedCredentials.
+   * @see https://core.telegram.org/bots/api#encryptedcredentials
+   */
+  selfie?: PassportFile;
+
+  /**
+   * Array of encrypted files with translated versions of documents provided 
+   * by the user. Available if requested for “passport”, “driver_license”, 
+   * “identity_card”, “internal_passport”, “utility_bill”, “bank_statement”, 
+   * “rental_agreement”, “passport_registration” and “temporary_registration” 
+   * types. Files can be decrypted and verified using the accompanying EncryptedCredentials.
+   * @see https://core.telegram.org/bots/api#encryptedcredentials
+   */
+  translation?: PassportFile[];
+
+  /**
+   * Base64-encoded element hash for using in PassportElementErrorUnspecified
+   * @see https://core.telegram.org/bots/api#passportelementerrorunspecified
+   */
+  hash: string;
+}
 
 /**
  * Contains data required for decrypting and authenticating 
  * EncryptedPassportElement. See the Telegram Passport Documentation for a 
  * complete description of the data decryption and authentication processes.
+ * @see https://core.telegram.org/bots/api#encryptedpassportelement
+ * @see https://core.telegram.org/passport#receiving-information
  */
-export interface EncryptedCredentials {}
+export interface EncryptedCredentials {
+  /**
+   * Base64-encoded encrypted JSON-serialized data with unique user's 
+   * payload, data hashes and secrets required for EncryptedPassportElement 
+   * decryption and authentication
+   * @see https://core.telegram.org/bots/api#encryptedpassportelement
+   */
+  data: string;
+
+  /**
+   * Base64-encoded data hash for data authentication
+   */
+  hash: string;
+
+  /**
+   * Base64-encoded secret, encrypted with the bot's public RSA key, required 
+   * for data decryption
+   */
+  secret: string;
+}
 
 /**
  * This object represents the content of a message to be sent as a result 
@@ -56,15 +157,21 @@ export type InputMedia = InputMediaPhoto | InputMediaVideo;
 export type InlineQueryResult = InlineQueryResultCachedAudio | InlineQueryResultCachedDocument | InlineQueryResultCachedGif | InlineQueryResultCachedMpeg4Gif | InlineQueryResultCachedPhoto | InlineQueryResultCachedSticker | InlineQueryResultCachedVideo | InlineQueryResultCachedVoice | InlineQueryResultArticle | InlineQueryResultAudio | InlineQueryResultContact | InlineQueryResultGame | InlineQueryResultDocument | InlineQueryResultGif | InlineQueryResultLocation | InlineQueryResultMpeg4Gif | InlineQueryResultPhoto | InlineQueryResultVenue | InlineQueryResultVideo | InlineQueryResultVoice;
 
 /**
+ * This object represents an error in the Telegram Passport element which 
+ * was submitted that should be resolved by the user
+ */
+export type PassportElementError = PassportElementErrorDataField | PassportElementErrorFrontSide | PassportElementErrorReverseSide | PassportElementErrorSelfie | PassportElementErrorFile | PassportElementErrorFiles | PassportElementErrorTranslationFile | PassportElementErrorTranslationFiles | PassportElementErrorUnspecified;
+
+/**
  * This object represents an incoming update.At most one of the optional 
  * parameters can be present in any given update.
  * @see https://core.telegram.org/bots/api#available-types
  */
 export interface Update {
   /**
-   * The update‘s unique identifier. Update identifiers start from a certain 
+   * The update's unique identifier. Update identifiers start from a certain 
    * positive number and increase sequentially. This ID becomes especially 
-   * handy if you’re using Webhooks, since it allows you to ignore repeated 
+   * handy if you're using Webhooks, since it allows you to ignore repeated 
    * updates or to restore the correct update sequence, should they get out 
    * of order. If there are no new updates for at least a week, then 
    * identifier of the next update will be chosen randomly instead of sequentially.
@@ -121,6 +228,106 @@ export interface Update {
    * New incoming pre-checkout query. Contains full information about checkout
    */
   pre_checkout_query?: PreCheckoutQuery;
+
+  /**
+   * New poll state. Bots receive only updates about stopped polls and polls, 
+   * which are sent by the bot
+   */
+  poll?: Poll;
+
+  /**
+   * A user changed their answer in a non-anonymous poll. Bots receive new 
+   * votes only in polls that were sent by the bot itself.
+   */
+  poll_answer?: PollAnswer;
+}
+
+/**
+ * Use this method to receive incoming updates using long polling (wiki). 
+ * An Array of Update objects is returned.
+ * @see https://en.wikipedia.org/wiki/Push_technology#Long_polling
+ * @see https://core.telegram.org/bots/api#update
+ */
+export interface GetUpdates {
+  /**
+   * Identifier of the first update to be returned. Must be greater by one 
+   * than the highest among the identifiers of previously received updates. 
+   * By default, updates starting with the earliest unconfirmed update are 
+   * returned. An update is considered confirmed as soon as getUpdates is 
+   * called with an offset higher than its update_id. The negative offset can 
+   * be specified to retrieve updates starting from -offset update from the 
+   * end of the updates queue. All previous updates will forgotten.
+   * @see https://core.telegram.org/bots/api#getupdates
+   */
+  offset?: number;
+
+  /**
+   * Limits the number of updates to be retrieved. Values between 1-100 are 
+   * accepted. Defaults to 100.
+   */
+  limit?: number;
+
+  /**
+   * Timeout in seconds for long polling. Defaults to 0, i.e. usual short 
+   * polling. Should be positive, short polling should be used for testing 
+   * purposes only.
+   */
+  timeout?: number;
+
+  /**
+   * A JSON-serialized list of the update types you want your bot to receive. 
+   * For example, specify [“message”, “edited_channel_post”, 
+   * “callback_query”] to only receive updates of these types. See Update for 
+   * a complete list of available update types. Specify an empty list to 
+   * receive all updates regardless of type (default). If not specified, the 
+   * previous setting will be used.Please note that this parameter doesn't 
+   * affect updates created before the call to the getUpdates, so unwanted 
+   * updates may be received for a short period of time.
+   * @see https://core.telegram.org/bots/api#update
+   */
+  allowed_updates?: string[];
+}
+
+/**
+ * Use this method to specify a url and receive incoming updates via an 
+ * outgoing webhook. Whenever there is an update for the bot, we will send 
+ * an HTTPS POST request to the specified url, containing a JSON-serialized 
+ * Update. In case of an unsuccessful request, we will give up after a 
+ * reasonable amount of attempts. Returns True on success.
+ * @see https://core.telegram.org/bots/api#update
+ */
+export interface SetWebhook {
+  /**
+   * HTTPS url to send updates to. Use an empty string to remove webhook integration
+   */
+  url: string;
+
+  /**
+   * Upload your public key certificate so that the root certificate in use 
+   * can be checked. See our self-signed guide for details.
+   * @see https://core.telegram.org/bots/api/bots/self-signed
+   */
+  certificate?: InputFile;
+
+  /**
+   * Maximum allowed number of simultaneous HTTPS connections to the webhook 
+   * for update delivery, 1-100. Defaults to 40. Use lower values to limit 
+   * the load on your bot's server, and higher values to increase your bot's throughput.
+   */
+  max_connections?: number;
+
+  /**
+   * A JSON-serialized list of the update types you want your bot to receive. 
+   * For example, specify [“message”, “edited_channel_post”, 
+   * “callback_query”] to only receive updates of these types. See Update for 
+   * a complete list of available update types. Specify an empty list to 
+   * receive all updates regardless of type (default). If not specified, the 
+   * previous setting will be used.Please note that this parameter doesn't 
+   * affect updates created before the call to the setWebhook, so unwanted 
+   * updates may be received for a short period of time.
+   * @see https://core.telegram.org/bots/api#update
+   */
+  allowed_updates?: string[];
 }
 
 /**
@@ -181,17 +388,17 @@ export interface User {
   is_bot: boolean;
 
   /**
-   * User‘s or bot’s first name
+   * User's or bot's first name
    */
   first_name: string;
 
   /**
-   * User‘s or bot’s last name
+   * User's or bot's last name
    */
   last_name?: string;
 
   /**
-   * User‘s or bot’s username
+   * User's or bot's username
    */
   username?: string;
 
@@ -200,6 +407,25 @@ export interface User {
    * @see https://en.wikipedia.org/wiki/IETF_language_tag
    */
   language_code?: string;
+
+  /**
+   * True, if the bot can be invited to groups. Returned only in getMe.
+   * @see https://core.telegram.org/bots/api#getme
+   */
+  can_join_groups?: boolean;
+
+  /**
+   * True, if privacy mode is disabled for the bot. Returned only in getMe.
+   * @see https://core.telegram.org/bots#privacy-mode
+   * @see https://core.telegram.org/bots/api#getme
+   */
+  can_read_all_group_messages?: boolean;
+
+  /**
+   * True, if the bot supports inline queries. Returned only in getMe.
+   * @see https://core.telegram.org/bots/api#getme
+   */
+  supports_inline_queries?: boolean;
 }
 
 /**
@@ -240,33 +466,46 @@ export interface Chat {
   last_name?: string;
 
   /**
-   * True if a group has ‘All Members Are Admins’ enabled.
-   */
-  all_members_are_administrators?: boolean;
-
-  /**
    * Chat photo. Returned only in getChat.
    * @see https://core.telegram.org/bots/api#getchat
    */
   photo?: ChatPhoto;
 
   /**
-   * Description, for supergroups and channel chats. Returned only in getChat.
+   * Description, for groups, supergroups and channel chats. Returned only in getChat.
    * @see https://core.telegram.org/bots/api#getchat
    */
   description?: string;
 
   /**
-   * Chat invite link, for supergroups and channel chats. Returned only in getChat.
+   * Chat invite link, for groups, supergroups and channel chats. Each 
+   * administrator in a chat generates their own invite links, so the bot 
+   * must first generate the link using exportChatInviteLink. Returned only 
+   * in getChat.
+   * @see https://core.telegram.org/bots/api#exportchatinvitelink
    * @see https://core.telegram.org/bots/api#getchat
    */
   invite_link?: string;
 
   /**
-   * Pinned message, for supergroups and channel chats. Returned only in getChat.
+   * Pinned message, for groups, supergroups and channels. Returned only in getChat.
    * @see https://core.telegram.org/bots/api#getchat
    */
   pinned_message?: Message;
+
+  /**
+   * Default chat member permissions, for groups and supergroups. Returned 
+   * only in getChat.
+   * @see https://core.telegram.org/bots/api#getchat
+   */
+  permissions?: ChatPermissions;
+
+  /**
+   * For supergroups, the minimum allowed delay between consecutive messages 
+   * sent by each unpriviledged user. Returned only in getChat.
+   * @see https://core.telegram.org/bots/api#getchat
+   */
+  slow_mode_delay?: number;
 
   /**
    * For supergroups, name of group sticker set. Returned only in getChat.
@@ -327,6 +566,12 @@ export interface Message {
   forward_signature?: string;
 
   /**
+   * Sender's name for messages forwarded from users who disallow adding a 
+   * link to their account in forwarded messages
+   */
+  forward_sender_name?: string;
+
+  /**
    * For forwarded messages, date the original message was sent in Unix time
    */
   forward_date?: number;
@@ -337,6 +582,11 @@ export interface Message {
    * is a reply.
    */
   reply_to_message?: Message;
+
+  /**
+   * Bot through which the message was sent
+   */
+  via_bot?: User;
 
   /**
    * Date the message was last edited in Unix time
@@ -354,7 +604,7 @@ export interface Message {
   author_signature?: string;
 
   /**
-   * For text messages, the actual UTF-8 text of the message, 0-4096 characters.
+   * For text messages, the actual UTF-8 text of the message, 0-4096 characters
    */
   text?: string;
 
@@ -365,10 +615,10 @@ export interface Message {
   entities?: MessageEntity[];
 
   /**
-   * For messages with a caption, special entities like usernames, URLs, bot 
-   * commands, etc. that appear in the caption
+   * Message is an animation, information about the animation. For backward 
+   * compatibility, when this field is set, the document field will also be set
    */
-  caption_entities?: MessageEntity[];
+  animation?: Animation;
 
   /**
    * Message is an audio file, information about the file
@@ -379,18 +629,6 @@ export interface Message {
    * Message is a general file, information about the file
    */
   document?: Document;
-
-  /**
-   * Message is an animation, information about the animation. For backward 
-   * compatibility, when this field is set, the document field will also be set
-   */
-  animation?: Animation;
-
-  /**
-   * Message is a game, information about the game. More about games »
-   * @see https://core.telegram.org/bots/api#games
-   */
-  game?: Game;
 
   /**
    * Message is a photo, available sizes of the photo
@@ -408,20 +646,27 @@ export interface Message {
   video?: Video;
 
   /**
-   * Message is a voice message, information about the file
-   */
-  voice?: Voice;
-
-  /**
    * Message is a video note, information about the video message
    * @see https://telegram.org/blog/video-messages-and-telescope
    */
   video_note?: VideoNote;
 
   /**
-   * Caption for the audio, document, photo, video or voice, 0-200 characters
+   * Message is a voice message, information about the file
+   */
+  voice?: Voice;
+
+  /**
+   * Caption for the animation, audio, document, photo, video or voice, 
+   * 0-1024 characters
    */
   caption?: string;
+
+  /**
+   * For messages with a caption, special entities like usernames, URLs, bot 
+   * commands, etc. that appear in the caption
+   */
+  caption_entities?: MessageEntity[];
 
   /**
    * Message is a shared contact, information about the contact
@@ -429,26 +674,31 @@ export interface Message {
   contact?: Contact;
 
   /**
-   * Message is a shared location, information about the location
+   * Message is a dice with random value from 1 to 6
    */
-  location?: Location;
+  dice?: Dice;
 
   /**
-   * Message is a venue, information about the venue
+   * Message is a game, information about the game. More about games »
+   * @see https://core.telegram.org/bots/api#games
+   */
+  game?: Game;
+
+  /**
+   * Message is a native poll, information about the poll
+   */
+  poll?: Poll;
+
+  /**
+   * Message is a venue, information about the venue. For backward 
+   * compatibility, when this field is set, the location field will also be set
    */
   venue?: Venue;
 
   /**
-   * New member that were added to the group or supergroup and information 
-   * about them (the bot itself may be one of these members)
+   * Message is a shared location, information about the location
    */
-  new_chat_participant?: User;
-
-  /**
-   * New member that were added to the group or supergroup and information 
-   * about them (the bot itself may be one of these members)
-   */
-  new_chat_member?: User;
+  location?: Location;
 
   /**
    * New members that were added to the group or supergroup and information 
@@ -483,8 +733,8 @@ export interface Message {
   group_chat_created?: true;
 
   /**
-   * Service message: the supergroup has been created. This field can‘t be 
-   * received in a message coming through updates, because bot can’t be a 
+   * Service message: the supergroup has been created. This field can't be 
+   * received in a message coming through updates, because bot can't be a 
    * member of a supergroup when it is created. It can only be found in 
    * reply_to_message if someone replies to a very first message in a 
    * directly created supergroup.
@@ -492,8 +742,8 @@ export interface Message {
   supergroup_chat_created?: true;
 
   /**
-   * Service message: the channel has been created. This field can‘t be 
-   * received in a message coming through updates, because bot can’t be a 
+   * Service message: the channel has been created. This field can't be 
+   * received in a message coming through updates, because bot can't be a 
    * member of a channel when it is created. It can only be found in 
    * reply_to_message if someone replies to a very first message in a channel.
    */
@@ -548,6 +798,12 @@ export interface Message {
    * Telegram Passport data
    */
   passport_data?: PassportData;
+
+  /**
+   * Inline keyboard attached to the message. login_url buttons are 
+   * represented as ordinary url buttons.
+   */
+  reply_markup?: InlineKeyboardMarkup;
 }
 
 /**
@@ -556,10 +812,13 @@ export interface Message {
  */
 export interface MessageEntity {
   /**
-   * Type of the entity. Can be mention (@username), hashtag, cashtag, 
-   * bot_command, url, email, phone_number, bold (bold text), italic (italic 
-   * text), code (monowidth string), pre (monowidth block), text_link (for 
-   * clickable text URLs), text_mention (for users without usernames)
+   * Type of the entity. Can be “mention” (@username), “hashtag” (#hashtag), 
+   * “cashtag” ($USD), “bot_command” (/start@jobs_bot), “url” 
+   * (https://telegram.org), “email” (do-not-reply@telegram.org), 
+   * “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic 
+   * text), “underline” (underlined text), “strikethrough” (strikethrough 
+   * text), “code” (monowidth string), “pre” (monowidth block), “text_link” 
+   * (for clickable text URLs), “text_mention” (for users without usernames)
    * @see https://telegram.org/blog/edit#new-mentions
    */
   type: string;
@@ -583,6 +842,11 @@ export interface MessageEntity {
    * For “text_mention” only, the mentioned user
    */
   user?: User;
+
+  /**
+   * For “pre” only, the programming language of the entity text
+   */
+  language?: string;
 }
 
 /**
@@ -595,9 +859,10 @@ export interface PhotoSize {
    * Identifier for this file, which can be used to download or reuse the file
    */
   file_id: string;
-  
+
   /**
-   * Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+   * Unique identifier for this file, which is supposed to be the same over 
+   * time and for different bots. Can't be used to download or reuse the file.
    */
   file_unique_id: string;
 
@@ -618,14 +883,72 @@ export interface PhotoSize {
 }
 
 /**
+ * This object represents an animation file (GIF or H.264/MPEG-4 AVC video 
+ * without sound).
+ */
+export interface Animation {
+  /**
+   * Identifier for this file, which can be used to download or reuse the file
+   */
+  file_id: string;
+
+  /**
+   * Unique identifier for this file, which is supposed to be the same over 
+   * time and for different bots. Can't be used to download or reuse the file.
+   */
+  file_unique_id: string;
+
+  /**
+   * Video width as defined by sender
+   */
+  width: number;
+
+  /**
+   * Video height as defined by sender
+   */
+  height: number;
+
+  /**
+   * Duration of the video in seconds as defined by sender
+   */
+  duration: number;
+
+  /**
+   * Animation thumbnail as defined by sender
+   */
+  thumb?: PhotoSize;
+
+  /**
+   * Original animation filename as defined by sender
+   */
+  file_name?: string;
+
+  /**
+   * MIME type of the file as defined by sender
+   */
+  mime_type?: string;
+
+  /**
+   * File size
+   */
+  file_size?: number;
+}
+
+/**
  * This object represents an audio file to be treated as music by the 
  * Telegram clients.
  */
 export interface Audio {
   /**
-   * Unique identifier for this file
+   * Identifier for this file, which can be used to download or reuse the file
    */
   file_id: string;
+
+  /**
+   * Unique identifier for this file, which is supposed to be the same over 
+   * time and for different bots. Can't be used to download or reuse the file.
+   */
+  file_unique_id: string;
 
   /**
    * Duration of the audio in seconds as defined by sender
@@ -667,9 +990,15 @@ export interface Audio {
  */
 export interface Document {
   /**
-   * Unique file identifier
+   * Identifier for this file, which can be used to download or reuse the file
    */
   file_id: string;
+
+  /**
+   * Unique identifier for this file, which is supposed to be the same over 
+   * time and for different bots. Can't be used to download or reuse the file.
+   */
+  file_unique_id: string;
 
   /**
    * Document thumbnail as defined by sender
@@ -697,9 +1026,15 @@ export interface Document {
  */
 export interface Video {
   /**
-   * Unique identifier for this file
+   * Identifier for this file, which can be used to download or reuse the file
    */
   file_id: string;
+
+  /**
+   * Unique identifier for this file, which is supposed to be the same over 
+   * time and for different bots. Can't be used to download or reuse the file.
+   */
+  file_unique_id: string;
 
   /**
    * Video width as defined by sender
@@ -733,88 +1068,23 @@ export interface Video {
 }
 
 /**
- * This object represents an animation file (GIF or H.264/MPEG-4 AVC video 
- * without sound).
- */
-export interface Animation {
-  /**
-   * Unique file identifier
-   */
-  file_id: string;
-
-  /**
-   * Video width as defined by sender
-   */
-  width: number;
-
-  /**
-   * Video height as defined by sender
-   */
-  height: number;
-
-  /**
-   * Duration of the video in seconds as defined by sender
-   */
-  duration: number;
-
-  /**
-   * Animation thumbnail as defined by sender
-   */
-  thumb?: PhotoSize;
-
-  /**
-   * Original animation filename as defined by sender
-   */
-  file_name?: string;
-
-  /**
-   * MIME type of the file as defined by sender
-   */
-  mime_type?: string;
-
-  /**
-   * File size
-   */
-  file_size?: number;
-}
-
-/**
- * This object represents a voice note.
- */
-export interface Voice {
-  /**
-   * Unique identifier for this file
-   */
-  file_id: string;
-
-  /**
-   * Duration of the audio in seconds as defined by sender
-   */
-  duration: number;
-
-  /**
-   * MIME type of the file as defined by sender
-   */
-  mime_type?: string;
-
-  /**
-   * File size
-   */
-  file_size?: number;
-}
-
-/**
  * This object represents a video message (available in Telegram apps as of v.4.0).
  * @see https://telegram.org/blog/video-messages-and-telescope
  */
 export interface VideoNote {
   /**
-   * Unique identifier for this file
+   * Identifier for this file, which can be used to download or reuse the file
    */
   file_id: string;
 
   /**
-   * Video width and height as defined by sender
+   * Unique identifier for this file, which is supposed to be the same over 
+   * time and for different bots. Can't be used to download or reuse the file.
+   */
+  file_unique_id: string;
+
+  /**
+   * Video width and height (diameter of the video message) as defined by sender
    */
   length: number;
 
@@ -827,6 +1097,37 @@ export interface VideoNote {
    * Video thumbnail
    */
   thumb?: PhotoSize;
+
+  /**
+   * File size
+   */
+  file_size?: number;
+}
+
+/**
+ * This object represents a voice note.
+ */
+export interface Voice {
+  /**
+   * Identifier for this file, which can be used to download or reuse the file
+   */
+  file_id: string;
+
+  /**
+   * Unique identifier for this file, which is supposed to be the same over 
+   * time and for different bots. Can't be used to download or reuse the file.
+   */
+  file_unique_id: string;
+
+  /**
+   * Duration of the audio in seconds as defined by sender
+   */
+  duration: number;
+
+  /**
+   * MIME type of the file as defined by sender
+   */
+  mime_type?: string;
 
   /**
    * File size
@@ -863,6 +1164,131 @@ export interface Contact {
    * @see https://en.wikipedia.org/wiki/VCard
    */
   vcard?: string;
+}
+
+/**
+ * This object represents an animated emoji that displays a random value.
+ */
+export interface Dice {
+  /**
+   * Emoji on which the dice throw animation is based
+   */
+  emoji: string;
+
+  /**
+   * Value of the dice, 1-6 for “” and “” base emoji, 1-5 for “” base emoji
+   */
+  value: number;
+}
+
+/**
+ * This object contains information about one answer option in a poll.
+ */
+export interface PollOption {
+  /**
+   * Option text, 1-100 characters
+   */
+  text: string;
+
+  /**
+   * Number of users that voted for this option
+   */
+  voter_count: number;
+}
+
+/**
+ * This object represents an answer of a user in a non-anonymous poll.
+ */
+export interface PollAnswer {
+  /**
+   * Unique poll identifier
+   */
+  poll_id: string;
+
+  /**
+   * The user, who changed the answer to the poll
+   */
+  user: User;
+
+  /**
+   * 0-based identifiers of answer options, chosen by the user. May be empty 
+   * if the user retracted their vote.
+   */
+  option_ids: number[];
+}
+
+/**
+ * This object contains information about a poll.
+ */
+export interface Poll {
+  /**
+   * Unique poll identifier
+   */
+  id: string;
+
+  /**
+   * Poll question, 1-255 characters
+   */
+  question: string;
+
+  /**
+   * List of poll options
+   */
+  options: PollOption[];
+
+  /**
+   * Total number of users that voted in the poll
+   */
+  total_voter_count: number;
+
+  /**
+   * True, if the poll is closed
+   */
+  is_closed: boolean;
+
+  /**
+   * True, if the poll is anonymous
+   */
+  is_anonymous: boolean;
+
+  /**
+   * Poll type, currently can be “regular” or “quiz”
+   */
+  type: string;
+
+  /**
+   * True, if the poll allows multiple answers
+   */
+  allows_multiple_answers: boolean;
+
+  /**
+   * 0-based identifier of the correct answer option. Available only for 
+   * polls in the quiz mode, which are closed, or was sent (not forwarded) by 
+   * the bot or to the private chat with the bot.
+   */
+  correct_option_id?: number;
+
+  /**
+   * Text that is shown when a user chooses an incorrect answer or taps on 
+   * the lamp icon in a quiz-style poll, 0-200 characters
+   */
+  explanation?: string;
+
+  /**
+   * Special entities like usernames, URLs, bot commands, etc. that appear in 
+   * the explanation
+   */
+  explanation_entities?: MessageEntity[];
+
+  /**
+   * Amount of time in seconds the poll will be active after creation
+   */
+  open_period?: number;
+
+  /**
+   * Point in time (Unix timestamp) when the poll will be automatically closed
+   */
+  close_date?: number;
 }
 
 /**
@@ -936,9 +1362,15 @@ export interface UserProfilePhotos {
  */
 export interface File {
   /**
-   * Unique identifier for this file
+   * Identifier for this file, which can be used to download or reuse the file
    */
   file_id: string;
+
+  /**
+   * Unique identifier for this file, which is supposed to be the same over 
+   * time and for different bots. Can't be used to download or reuse the file.
+   */
+  file_unique_id: string;
 
   /**
    * File size, if known
@@ -985,8 +1417,8 @@ export interface ReplyKeyboardMarkup {
    * only. Targets: 1) users that are @mentioned in the text of the Message 
    * object; 2) if the bot's message is a reply (has reply_to_message_id), 
    * sender of the original message.Example: A user requests to change the 
-   * bot‘s language, bot replies to the request with a keyboard to select the 
-   * new language. Other users in the group don’t see the keyboard.
+   * bot's language, bot replies to the request with a keyboard to select the 
+   * new language. Other users in the group don't see the keyboard.
    * @see https://core.telegram.org/bots/api#message
    */
   selective?: boolean;
@@ -995,7 +1427,8 @@ export interface ReplyKeyboardMarkup {
 /**
  * This object represents one button of the reply keyboard. For simple text 
  * buttons String can be used instead of this object to specify text of the 
- * button. Optional fields are mutually exclusive.
+ * button. Optional fields request_contact, request_location, and 
+ * request_poll are mutually exclusive.
  */
 export interface KeyboardButton {
   /**
@@ -1015,6 +1448,25 @@ export interface KeyboardButton {
    * pressed. Available in private chats only
    */
   request_location?: boolean;
+
+  /**
+   * If specified, the user will be asked to create a poll and send it to the 
+   * bot when the button is pressed. Available in private chats only
+   */
+  request_poll?: KeyboardButtonPollType;
+}
+
+/**
+ * This object represents type of a poll, which is allowed to be created 
+ * and sent when the corresponding button is pressed.
+ */
+export interface KeyboardButtonPollType {
+  /**
+   * If quiz is passed, the user will be allowed to create only polls in the 
+   * quiz mode. If regular is passed, only regular polls will be allowed. 
+   * Otherwise, the user will be allowed to create a poll of any type.
+   */
+  type?: string;
 }
 
 /**
@@ -1077,6 +1529,13 @@ export interface InlineKeyboardButton {
   url?: string;
 
   /**
+   * An HTTP URL used to automatically authorize the user. Can be used as a 
+   * replacement for the Telegram Login Widget.
+   * @see https://core.telegram.org/widgets/login
+   */
+  login_url?: LoginUrl;
+
+  /**
    * Data to be sent in a callback query to the bot when button is pressed, 
    * 1-64 bytes
    * @see https://core.telegram.org/bots/api#callbackquery
@@ -1085,9 +1544,9 @@ export interface InlineKeyboardButton {
 
   /**
    * If set, pressing the button will prompt the user to select one of their 
-   * chats, open that chat and insert the bot‘s username and the specified 
+   * chats, open that chat and insert the bot's username and the specified 
    * inline query in the input field. Can be empty, in which case just the 
-   * bot’s username will be inserted.Note: This offers an easy way for users 
+   * bot's username will be inserted.Note: This offers an easy way for users 
    * to start using your bot in inline mode when they are currently in a 
    * private chat with it. Especially useful when combined with switch_pm… 
    * actions – in this case the user will be automatically returned to the 
@@ -1098,9 +1557,9 @@ export interface InlineKeyboardButton {
   switch_inline_query?: string;
 
   /**
-   * If set, pressing the button will insert the bot‘s username and the 
+   * If set, pressing the button will insert the bot's username and the 
    * specified inline query in the current chat's input field. Can be empty, 
-   * in which case only the bot’s username will be inserted.This offers a 
+   * in which case only the bot's username will be inserted.This offers a 
    * quick way for the user to open your bot in inline mode in the same chat 
    * – good for selecting something from multiple options.
    */
@@ -1119,6 +1578,48 @@ export interface InlineKeyboardButton {
    * @see https://core.telegram.org/bots/api#payments
    */
   pay?: boolean;
+}
+
+/**
+ * This object represents a parameter of the inline keyboard button used to 
+ * automatically authorize a user. Serves as a great replacement for the 
+ * Telegram Login Widget when the user is coming from Telegram. All the 
+ * user needs to do is tap/click a button and confirm that they want to log in:
+ * @see https://core.telegram.org/widgets/login
+ */
+export interface LoginUrl {
+  /**
+   * An HTTP URL to be opened with user authorization data added to the query 
+   * string when the button is pressed. If the user refuses to provide 
+   * authorization data, the original URL without information about the user 
+   * will be opened. The data added is the same as described in Receiving 
+   * authorization data.NOTE: You must always check the hash of the received 
+   * data to verify the authentication and the integrity of the data as 
+   * described in Checking authorization.
+   * @see https://core.telegram.org/widgets/login#receiving-authorization-data
+   * @see https://core.telegram.org/widgets/login#checking-authorization
+   */
+  url: string;
+
+  /**
+   * New text of the button in forwarded messages.
+   */
+  forward_text?: string;
+
+  /**
+   * Username of a bot, which will be used for user authorization. See 
+   * Setting up a bot for more details. If not specified, the current bot's 
+   * username will be assumed. The url's domain must be the same as the 
+   * domain linked with the bot. See Linking your domain to the bot for more details.
+   * @see https://core.telegram.org/widgets/login#setting-up-a-bot
+   * @see https://core.telegram.org/widgets/login#linking-your-domain-to-the-bot
+   */
+  bot_username?: string;
+
+  /**
+   * Pass True to request the permission for your bot to send messages to the user.
+   */
+  request_write_access?: boolean;
 }
 
 /**
@@ -1178,8 +1679,8 @@ export interface CallbackQuery {
 
 /**
  * Upon receiving a message with this object, Telegram clients will display 
- * a reply interface to the user (act as if the user has selected the bot‘s 
- * message and tapped ’Reply'). This can be extremely useful if you want to 
+ * a reply interface to the user (act as if the user has selected the bot's 
+ * message and tapped 'Reply'). This can be extremely useful if you want to 
  * create user-friendly step-by-step interfaces without having to sacrifice 
  * privacy mode.
  * @see https://core.telegram.org/bots/api/bots#privacy-mode
@@ -1187,7 +1688,7 @@ export interface CallbackQuery {
 export interface ForceReply {
   /**
    * Shows reply interface to the user, as if they manually selected the 
-   * bot‘s message and tapped ’Reply'
+   * bot's message and tapped 'Reply'
    */
   force_reply: true;
 
@@ -1206,16 +1707,30 @@ export interface ForceReply {
  */
 export interface ChatPhoto {
   /**
-   * Unique file identifier of small (160x160) chat photo. This file_id can 
-   * be used only for photo download.
+   * File identifier of small (160x160) chat photo. This file_id can be used 
+   * only for photo download and only for as long as the photo is not changed.
    */
   small_file_id: string;
 
   /**
-   * Unique file identifier of big (640x640) chat photo. This file_id can be 
-   * used only for photo download.
+   * Unique file identifier of small (160x160) chat photo, which is supposed 
+   * to be the same over time and for different bots. Can't be used to 
+   * download or reuse the file.
+   */
+  small_file_unique_id: string;
+
+  /**
+   * File identifier of big (640x640) chat photo. This file_id can be used 
+   * only for photo download and only for as long as the photo is not changed.
    */
   big_file_id: string;
+
+  /**
+   * Unique file identifier of big (640x640) chat photo, which is supposed to 
+   * be the same over time and for different bots. Can't be used to download 
+   * or reuse the file.
+   */
+  big_file_unique_id: string;
 }
 
 /**
@@ -1234,8 +1749,13 @@ export interface ChatMember {
   status: string;
 
   /**
+   * Owner and administrators only. Custom title for this user
+   */
+  custom_title?: string;
+
+  /**
    * Restricted and kicked only. Date when restrictions will be lifted for 
-   * this user, unix time
+   * this user; unix time
    */
   until_date?: number;
 
@@ -1246,20 +1766,14 @@ export interface ChatMember {
   can_be_edited?: boolean;
 
   /**
-   * Administrators only. True, if the administrator can change the chat 
-   * title, photo and other settings
-   */
-  can_change_info?: boolean;
-
-  /**
-   * Administrators only. True, if the administrator can post in the channel, 
+   * Administrators only. True, if the administrator can post in the channel; 
    * channels only
    */
   can_post_messages?: boolean;
 
   /**
    * Administrators only. True, if the administrator can edit messages of 
-   * other users and can pin messages, channels only
+   * other users and can pin messages; channels only
    */
   can_edit_messages?: boolean;
 
@@ -1270,54 +1784,137 @@ export interface ChatMember {
   can_delete_messages?: boolean;
 
   /**
-   * Administrators only. True, if the administrator can invite new users to 
-   * the chat
-   */
-  can_invite_users?: boolean;
-
-  /**
    * Administrators only. True, if the administrator can restrict, ban or 
    * unban chat members
    */
   can_restrict_members?: boolean;
 
   /**
-   * Administrators only. True, if the administrator can pin messages, 
-   * supergroups only
-   */
-  can_pin_messages?: boolean;
-
-  /**
    * Administrators only. True, if the administrator can add new 
-   * administrators with a subset of his own privileges or demote 
+   * administrators with a subset of their own privileges or demote 
    * administrators that he has promoted, directly or indirectly (promoted by 
    * administrators that were appointed by the user)
    */
   can_promote_members?: boolean;
 
   /**
-   * Restricted only. True, if the user can send text messages, contacts, 
-   * locations and venues
+   * Administrators and restricted only. True, if the user is allowed to 
+   * change the chat title, photo and other settings
+   */
+  can_change_info?: boolean;
+
+  /**
+   * Administrators and restricted only. True, if the user is allowed to 
+   * invite new users to the chat
+   */
+  can_invite_users?: boolean;
+
+  /**
+   * Administrators and restricted only. True, if the user is allowed to pin 
+   * messages; groups and supergroups only
+   */
+  can_pin_messages?: boolean;
+
+  /**
+   * Restricted only. True, if the user is a member of the chat at the moment 
+   * of the request
+   */
+  is_member?: boolean;
+
+  /**
+   * Restricted only. True, if the user is allowed to send text messages, 
+   * contacts, locations and venues
    */
   can_send_messages?: boolean;
 
   /**
-   * Restricted only. True, if the user can send audios, documents, photos, 
-   * videos, video notes and voice notes, implies can_send_messages
+   * Restricted only. True, if the user is allowed to send audios, documents, 
+   * photos, videos, video notes and voice notes
    */
   can_send_media_messages?: boolean;
 
   /**
-   * Restricted only. True, if the user can send animations, games, stickers 
-   * and use inline bots, implies can_send_media_messages
+   * Restricted only. True, if the user is allowed to send polls
+   */
+  can_send_polls?: boolean;
+
+  /**
+   * Restricted only. True, if the user is allowed to send animations, games, 
+   * stickers and use inline bots
    */
   can_send_other_messages?: boolean;
 
   /**
-   * Restricted only. True, if user may add web page previews to his 
-   * messages, implies can_send_media_messages
+   * Restricted only. True, if the user is allowed to add web page previews 
+   * to their messages
    */
   can_add_web_page_previews?: boolean;
+}
+
+/**
+ * Describes actions that a non-administrator user is allowed to take in a chat.
+ */
+export interface ChatPermissions {
+  /**
+   * True, if the user is allowed to send text messages, contacts, locations 
+   * and venues
+   */
+  can_send_messages?: boolean;
+
+  /**
+   * True, if the user is allowed to send audios, documents, photos, videos, 
+   * video notes and voice notes, implies can_send_messages
+   */
+  can_send_media_messages?: boolean;
+
+  /**
+   * True, if the user is allowed to send polls, implies can_send_messages
+   */
+  can_send_polls?: boolean;
+
+  /**
+   * True, if the user is allowed to send animations, games, stickers and use 
+   * inline bots, implies can_send_media_messages
+   */
+  can_send_other_messages?: boolean;
+
+  /**
+   * True, if the user is allowed to add web page previews to their messages, 
+   * implies can_send_media_messages
+   */
+  can_add_web_page_previews?: boolean;
+
+  /**
+   * True, if the user is allowed to change the chat title, photo and other 
+   * settings. Ignored in public supergroups
+   */
+  can_change_info?: boolean;
+
+  /**
+   * True, if the user is allowed to invite new users to the chat
+   */
+  can_invite_users?: boolean;
+
+  /**
+   * True, if the user is allowed to pin messages. Ignored in public supergroups
+   */
+  can_pin_messages?: boolean;
+}
+
+/**
+ * This object represents a bot command.
+ */
+export interface BotCommand {
+  /**
+   * Text of the command, 1-32 characters. Can contain only lowercase English 
+   * letters, digits and underscores.
+   */
+  command: string;
+
+  /**
+   * Description of the command, 3-256 characters.
+   */
+  description: string;
 }
 
 /**
@@ -1360,15 +1957,13 @@ export interface InputMediaPhoto {
   media: string;
 
   /**
-   * Caption of the photo to be sent, 0-200 characters
+   * Caption of the photo to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the photo caption. See formatting options 
+   * for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -1394,27 +1989,26 @@ export interface InputMediaVideo {
   media: string;
 
   /**
-   * Thumbnail of the file sent. The thumbnail should be in JPEG format and 
-   * less than 200 kB in size. A thumbnail‘s width and height should not 
-   * exceed 90. Ignored if the file is not uploaded using 
-   * multipart/form-data. Thumbnails can’t be reused and can be only uploaded 
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+   * the file is supported server-side. The thumbnail should be in JPEG 
+   * format and less than 200 kB in size. A thumbnail's width and height 
+   * should not exceed 320. Ignored if the file is not uploaded using 
+   * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
    * as a new file, so you can pass “attach://<file_attach_name>” if the 
    * thumbnail was uploaded using multipart/form-data under 
    * <file_attach_name>. More info on Sending Files »
    * @see https://core.telegram.org/bots/api#sending-files
    */
-  thumb?: InputFile | string;
+  thumb?: (InputFile | string);
 
   /**
-   * Caption of the video to be sent, 0-200 characters
+   * Caption of the video to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the video caption. See formatting options 
+   * for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -1461,27 +2055,26 @@ export interface InputMediaAnimation {
   media: string;
 
   /**
-   * Thumbnail of the file sent. The thumbnail should be in JPEG format and 
-   * less than 200 kB in size. A thumbnail‘s width and height should not 
-   * exceed 90. Ignored if the file is not uploaded using 
-   * multipart/form-data. Thumbnails can’t be reused and can be only uploaded 
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+   * the file is supported server-side. The thumbnail should be in JPEG 
+   * format and less than 200 kB in size. A thumbnail's width and height 
+   * should not exceed 320. Ignored if the file is not uploaded using 
+   * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
    * as a new file, so you can pass “attach://<file_attach_name>” if the 
    * thumbnail was uploaded using multipart/form-data under 
    * <file_attach_name>. More info on Sending Files »
    * @see https://core.telegram.org/bots/api#sending-files
    */
-  thumb?: InputFile | string;
+  thumb?: (InputFile | string);
 
   /**
-   * Caption of the animation to be sent, 0-200 characters
+   * Caption of the animation to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the animation caption. See formatting 
+   * options for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -1522,27 +2115,26 @@ export interface InputMediaAudio {
   media: string;
 
   /**
-   * Thumbnail of the file sent. The thumbnail should be in JPEG format and 
-   * less than 200 kB in size. A thumbnail‘s width and height should not 
-   * exceed 90. Ignored if the file is not uploaded using 
-   * multipart/form-data. Thumbnails can’t be reused and can be only uploaded 
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+   * the file is supported server-side. The thumbnail should be in JPEG 
+   * format and less than 200 kB in size. A thumbnail's width and height 
+   * should not exceed 320. Ignored if the file is not uploaded using 
+   * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
    * as a new file, so you can pass “attach://<file_attach_name>” if the 
    * thumbnail was uploaded using multipart/form-data under 
    * <file_attach_name>. More info on Sending Files »
    * @see https://core.telegram.org/bots/api#sending-files
    */
-  thumb?: InputFile | string;
+  thumb?: (InputFile | string);
 
   /**
-   * Caption of the audio to be sent, 0-200 characters
+   * Caption of the audio to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the audio caption. See formatting options 
+   * for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -1583,30 +2175,1790 @@ export interface InputMediaDocument {
   media: string;
 
   /**
-   * Thumbnail of the file sent. The thumbnail should be in JPEG format and 
-   * less than 200 kB in size. A thumbnail‘s width and height should not 
-   * exceed 90. Ignored if the file is not uploaded using 
-   * multipart/form-data. Thumbnails can’t be reused and can be only uploaded 
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+   * the file is supported server-side. The thumbnail should be in JPEG 
+   * format and less than 200 kB in size. A thumbnail's width and height 
+   * should not exceed 320. Ignored if the file is not uploaded using 
+   * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
    * as a new file, so you can pass “attach://<file_attach_name>” if the 
    * thumbnail was uploaded using multipart/form-data under 
    * <file_attach_name>. More info on Sending Files »
    * @see https://core.telegram.org/bots/api#sending-files
    */
-  thumb?: InputFile | string;
+  thumb?: (InputFile | string);
 
   /**
-   * Caption of the document to be sent, 0-200 characters
+   * Caption of the document to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the document caption. See formatting 
+   * options for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
+}
+
+/**
+ * Use this method to send text messages. On success, the sent Message is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendMessage {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Text of the message to be sent, 1-4096 characters after entities parsing
+   */
+  text: string;
+
+  /**
+   * Mode for parsing entities in the message text. See formatting options 
+   * for more details.
+   * @see https://core.telegram.org/bots/api#formatting-options
+   */
+  parse_mode?: string;
+
+  /**
+   * Disables link previews for links in this message
+   */
+  disable_web_page_preview?: boolean;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method to forward messages of any kind. On success, the sent 
+ * Message is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface ForwardMessage {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Unique identifier for the chat where the original message was sent (or 
+   * channel username in the format @channelusername)
+   */
+  from_chat_id: (number | string);
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * Message identifier in the chat specified in from_chat_id
+   */
+  message_id: number;
+}
+
+/**
+ * Use this method to send photos. On success, the sent Message is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendPhoto {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Photo to send. Pass a file_id as String to send a photo that exists on 
+   * the Telegram servers (recommended), pass an HTTP URL as a String for 
+   * Telegram to get a photo from the Internet, or upload a new photo using 
+   * multipart/form-data. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  photo: (InputFile | string);
+
+  /**
+   * Photo caption (may also be used when resending photos by file_id), 
+   * 0-1024 characters after entities parsing
+   */
+  caption?: string;
+
+  /**
+   * Mode for parsing entities in the photo caption. See formatting options 
+   * for more details.
+   * @see https://core.telegram.org/bots/api#formatting-options
+   */
+  parse_mode?: string;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method to send audio files, if you want Telegram clients to 
+ * display them in the music player. Your audio must be in the .MP3 or .M4A 
+ * format. On success, the sent Message is returned. Bots can currently 
+ * send audio files of up to 50 MB in size, this limit may be changed in 
+ * the future.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendAudio {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Audio file to send. Pass a file_id as String to send an audio file that 
+   * exists on the Telegram servers (recommended), pass an HTTP URL as a 
+   * String for Telegram to get an audio file from the Internet, or upload a 
+   * new one using multipart/form-data. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  audio: (InputFile | string);
+
+  /**
+   * Audio caption, 0-1024 characters after entities parsing
+   */
+  caption?: string;
+
+  /**
+   * Mode for parsing entities in the audio caption. See formatting options 
+   * for more details.
+   * @see https://core.telegram.org/bots/api#formatting-options
+   */
+  parse_mode?: string;
+
+  /**
+   * Duration of the audio in seconds
+   */
+  duration?: number;
+
+  /**
+   * Performer
+   */
+  performer?: string;
+
+  /**
+   * Track name
+   */
+  title?: string;
+
+  /**
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+   * the file is supported server-side. The thumbnail should be in JPEG 
+   * format and less than 200 kB in size. A thumbnail's width and height 
+   * should not exceed 320. Ignored if the file is not uploaded using 
+   * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
+   * as a new file, so you can pass “attach://<file_attach_name>” if the 
+   * thumbnail was uploaded using multipart/form-data under 
+   * <file_attach_name>. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  thumb?: (InputFile | string);
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method to send general files. On success, the sent Message is 
+ * returned. Bots can currently send files of any type of up to 50 MB in 
+ * size, this limit may be changed in the future.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendDocument {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * File to send. Pass a file_id as String to send a file that exists on the 
+   * Telegram servers (recommended), pass an HTTP URL as a String for 
+   * Telegram to get a file from the Internet, or upload a new one using 
+   * multipart/form-data. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  document: (InputFile | string);
+
+  /**
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+   * the file is supported server-side. The thumbnail should be in JPEG 
+   * format and less than 200 kB in size. A thumbnail's width and height 
+   * should not exceed 320. Ignored if the file is not uploaded using 
+   * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
+   * as a new file, so you can pass “attach://<file_attach_name>” if the 
+   * thumbnail was uploaded using multipart/form-data under 
+   * <file_attach_name>. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  thumb?: (InputFile | string);
+
+  /**
+   * Document caption (may also be used when resending documents by file_id), 
+   * 0-1024 characters after entities parsing
+   */
+  caption?: string;
+
+  /**
+   * Mode for parsing entities in the document caption. See formatting 
+   * options for more details.
+   * @see https://core.telegram.org/bots/api#formatting-options
+   */
+  parse_mode?: string;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method to send video files, Telegram clients support mp4 videos 
+ * (other formats may be sent as Document). On success, the sent Message is 
+ * returned. Bots can currently send video files of up to 50 MB in size, 
+ * this limit may be changed in the future.
+ * @see https://core.telegram.org/bots/api#document
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendVideo {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Video to send. Pass a file_id as String to send a video that exists on 
+   * the Telegram servers (recommended), pass an HTTP URL as a String for 
+   * Telegram to get a video from the Internet, or upload a new video using 
+   * multipart/form-data. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  video: (InputFile | string);
+
+  /**
+   * Duration of sent video in seconds
+   */
+  duration?: number;
+
+  /**
+   * Video width
+   */
+  width?: number;
+
+  /**
+   * Video height
+   */
+  height?: number;
+
+  /**
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+   * the file is supported server-side. The thumbnail should be in JPEG 
+   * format and less than 200 kB in size. A thumbnail's width and height 
+   * should not exceed 320. Ignored if the file is not uploaded using 
+   * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
+   * as a new file, so you can pass “attach://<file_attach_name>” if the 
+   * thumbnail was uploaded using multipart/form-data under 
+   * <file_attach_name>. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  thumb?: (InputFile | string);
+
+  /**
+   * Video caption (may also be used when resending videos by file_id), 
+   * 0-1024 characters after entities parsing
+   */
+  caption?: string;
+
+  /**
+   * Mode for parsing entities in the video caption. See formatting options 
+   * for more details.
+   * @see https://core.telegram.org/bots/api#formatting-options
+   */
+  parse_mode?: string;
+
+  /**
+   * Pass True, if the uploaded video is suitable for streaming
+   */
+  supports_streaming?: boolean;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method to send animation files (GIF or H.264/MPEG-4 AVC video 
+ * without sound). On success, the sent Message is returned. Bots can 
+ * currently send animation files of up to 50 MB in size, this limit may be 
+ * changed in the future.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendAnimation {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Animation to send. Pass a file_id as String to send an animation that 
+   * exists on the Telegram servers (recommended), pass an HTTP URL as a 
+   * String for Telegram to get an animation from the Internet, or upload a 
+   * new animation using multipart/form-data. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  animation: (InputFile | string);
+
+  /**
+   * Duration of sent animation in seconds
+   */
+  duration?: number;
+
+  /**
+   * Animation width
+   */
+  width?: number;
+
+  /**
+   * Animation height
+   */
+  height?: number;
+
+  /**
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+   * the file is supported server-side. The thumbnail should be in JPEG 
+   * format and less than 200 kB in size. A thumbnail's width and height 
+   * should not exceed 320. Ignored if the file is not uploaded using 
+   * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
+   * as a new file, so you can pass “attach://<file_attach_name>” if the 
+   * thumbnail was uploaded using multipart/form-data under 
+   * <file_attach_name>. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  thumb?: (InputFile | string);
+
+  /**
+   * Animation caption (may also be used when resending animation by 
+   * file_id), 0-1024 characters after entities parsing
+   */
+  caption?: string;
+
+  /**
+   * Mode for parsing entities in the animation caption. See formatting 
+   * options for more details.
+   * @see https://core.telegram.org/bots/api#formatting-options
+   */
+  parse_mode?: string;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method to send audio files, if you want Telegram clients to 
+ * display the file as a playable voice message. For this to work, your 
+ * audio must be in an .OGG file encoded with OPUS (other formats may be 
+ * sent as Audio or Document). On success, the sent Message is returned. 
+ * Bots can currently send voice messages of up to 50 MB in size, this 
+ * limit may be changed in the future.
+ * @see https://core.telegram.org/bots/api#audio
+ * @see https://core.telegram.org/bots/api#document
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendVoice {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Audio file to send. Pass a file_id as String to send a file that exists 
+   * on the Telegram servers (recommended), pass an HTTP URL as a String for 
+   * Telegram to get a file from the Internet, or upload a new one using 
+   * multipart/form-data. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  voice: (InputFile | string);
+
+  /**
+   * Voice message caption, 0-1024 characters after entities parsing
+   */
+  caption?: string;
+
+  /**
+   * Mode for parsing entities in the voice message caption. See formatting 
+   * options for more details.
+   * @see https://core.telegram.org/bots/api#formatting-options
+   */
+  parse_mode?: string;
+
+  /**
+   * Duration of the voice message in seconds
+   */
+  duration?: number;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * As of v.4.0, Telegram clients support rounded square mp4 videos of up to 
+ * 1 minute long. Use this method to send video messages. On success, the 
+ * sent Message is returned.
+ * @see https://telegram.org/blog/video-messages-and-telescope
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendVideoNote {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Video note to send. Pass a file_id as String to send a video note that 
+   * exists on the Telegram servers (recommended) or upload a new video using 
+   * multipart/form-data. More info on Sending Files ». Sending video notes 
+   * by a URL is currently unsupported
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  video_note: (InputFile | string);
+
+  /**
+   * Duration of sent video in seconds
+   */
+  duration?: number;
+
+  /**
+   * Video width and height, i.e. diameter of the video message
+   */
+  length?: number;
+
+  /**
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+   * the file is supported server-side. The thumbnail should be in JPEG 
+   * format and less than 200 kB in size. A thumbnail's width and height 
+   * should not exceed 320. Ignored if the file is not uploaded using 
+   * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
+   * as a new file, so you can pass “attach://<file_attach_name>” if the 
+   * thumbnail was uploaded using multipart/form-data under 
+   * <file_attach_name>. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  thumb?: (InputFile | string);
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method to send a group of photos or videos as an album. On 
+ * success, an array of the sent Messages is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendMediaGroup {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * A JSON-serialized array describing photos and videos to be sent, must 
+   * include 2-10 items
+   */
+  media: (InputMediaPhoto | InputMediaVideo)[];
+
+  /**
+   * Sends the messages silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the messages are a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+}
+
+/**
+ * Use this method to send point on the map. On success, the sent Message 
+ * is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendLocation {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Latitude of the location
+   */
+  latitude: number;
+
+  /**
+   * Longitude of the location
+   */
+  longitude: number;
+
+  /**
+   * Period in seconds for which the location will be updated (see Live 
+   * Locations, should be between 60 and 86400.
+   * @see https://telegram.org/blog/live-locations
+   */
+  live_period?: number;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method to edit live location messages. A location can be edited 
+ * until its live_period expires or editing is explicitly disabled by a 
+ * call to stopMessageLiveLocation. On success, if the edited message was 
+ * sent by the bot, the edited Message is returned, otherwise True is returned.
+ * @see https://core.telegram.org/bots/api#stopmessagelivelocation
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface EditMessageLiveLocation {
+  /**
+   * Required if inline_message_id is not specified. Unique identifier for 
+   * the target chat or username of the target channel (in the format @channelusername)
+   */
+  chat_id?: (number | string);
+
+  /**
+   * Required if inline_message_id is not specified. Identifier of the 
+   * message to edit
+   */
+  message_id?: number;
+
+  /**
+   * Required if chat_id and message_id are not specified. Identifier of the 
+   * inline message
+   */
+  inline_message_id?: string;
+
+  /**
+   * Latitude of new location
+   */
+  latitude: number;
+
+  /**
+   * Longitude of new location
+   */
+  longitude: number;
+
+  /**
+   * A JSON-serialized object for a new inline keyboard.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   */
+  reply_markup?: InlineKeyboardMarkup;
+}
+
+/**
+ * Use this method to stop updating a live location message before 
+ * live_period expires. On success, if the message was sent by the bot, the 
+ * sent Message is returned, otherwise True is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface StopMessageLiveLocation {
+  /**
+   * Required if inline_message_id is not specified. Unique identifier for 
+   * the target chat or username of the target channel (in the format @channelusername)
+   */
+  chat_id?: (number | string);
+
+  /**
+   * Required if inline_message_id is not specified. Identifier of the 
+   * message with live location to stop
+   */
+  message_id?: number;
+
+  /**
+   * Required if chat_id and message_id are not specified. Identifier of the 
+   * inline message
+   */
+  inline_message_id?: string;
+
+  /**
+   * A JSON-serialized object for a new inline keyboard.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   */
+  reply_markup?: InlineKeyboardMarkup;
+}
+
+/**
+ * Use this method to send information about a venue. On success, the sent 
+ * Message is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendVenue {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Latitude of the venue
+   */
+  latitude: number;
+
+  /**
+   * Longitude of the venue
+   */
+  longitude: number;
+
+  /**
+   * Name of the venue
+   */
+  title: string;
+
+  /**
+   * Address of the venue
+   */
+  address: string;
+
+  /**
+   * Foursquare identifier of the venue
+   */
+  foursquare_id?: string;
+
+  /**
+   * Foursquare type of the venue, if known. (For example, 
+   * “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
+   */
+  foursquare_type?: string;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method to send phone contacts. On success, the sent Message is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendContact {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Contact's phone number
+   */
+  phone_number: string;
+
+  /**
+   * Contact's first name
+   */
+  first_name: string;
+
+  /**
+   * Contact's last name
+   */
+  last_name?: string;
+
+  /**
+   * Additional data about the contact in the form of a vCard, 0-2048 bytes
+   * @see https://en.wikipedia.org/wiki/VCard
+   */
+  vcard?: string;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove keyboard or to 
+   * force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method to send a native poll. On success, the sent Message is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendPoll {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Poll question, 1-255 characters
+   */
+  question: string;
+
+  /**
+   * A JSON-serialized list of answer options, 2-10 strings 1-100 characters each
+   */
+  options: string[];
+
+  /**
+   * True, if the poll needs to be anonymous, defaults to True
+   */
+  is_anonymous?: boolean;
+
+  /**
+   * Poll type, “quiz” or “regular”, defaults to “regular”
+   */
+  type?: string;
+
+  /**
+   * True, if the poll allows multiple answers, ignored for polls in quiz 
+   * mode, defaults to False
+   */
+  allows_multiple_answers?: boolean;
+
+  /**
+   * 0-based identifier of the correct answer option, required for polls in 
+   * quiz mode
+   */
+  correct_option_id?: number;
+
+  /**
+   * Text that is shown when a user chooses an incorrect answer or taps on 
+   * the lamp icon in a quiz-style poll, 0-200 characters with at most 2 line 
+   * feeds after entities parsing
+   */
+  explanation?: string;
+
+  /**
+   * Mode for parsing entities in the explanation. See formatting options for 
+   * more details.
+   * @see https://core.telegram.org/bots/api#formatting-options
+   */
+  explanation_parse_mode?: string;
+
+  /**
+   * Amount of time in seconds the poll will be active after creation, 5-600. 
+   * Can't be used together with close_date.
+   */
+  open_period?: number;
+
+  /**
+   * Point in time (Unix timestamp) when the poll will be automatically 
+   * closed. Must be at least 5 and no more than 600 seconds in the future. 
+   * Can't be used together with open_period.
+   */
+  close_date?: number;
+
+  /**
+   * Pass True, if the poll needs to be immediately closed. This can be 
+   * useful for poll preview.
+   */
+  is_closed?: boolean;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method to send an animated emoji that will display a random 
+ * value. On success, the sent Message is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendDice {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Emoji on which the dice throw animation is based. Currently, must be one 
+   * of “”, “”, or “”. Dice can have values 1-6 for “” and “”, and values 1-5 
+   * for “”. Defaults to “”
+   */
+  emoji?: string;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method when you need to tell the user that something is 
+ * happening on the bot's side. The status is set for 5 seconds or less 
+ * (when a message arrives from your bot, Telegram clients clear its typing 
+ * status). Returns True on success.
+ */
+export interface SendChatAction {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Type of action to broadcast. Choose one, depending on what the user is 
+   * about to receive: typing for text messages, upload_photo for photos, 
+   * record_video or upload_video for videos, record_audio or upload_audio 
+   * for audio files, upload_document for general files, find_location for 
+   * location data, record_video_note or upload_video_note for video notes.
+   * @see https://core.telegram.org/bots/api#sendmessage
+   * @see https://core.telegram.org/bots/api#sendphoto
+   * @see https://core.telegram.org/bots/api#sendvideo
+   * @see https://core.telegram.org/bots/api#sendaudio
+   * @see https://core.telegram.org/bots/api#senddocument
+   * @see https://core.telegram.org/bots/api#sendlocation
+   * @see https://core.telegram.org/bots/api#sendvideonote
+   */
+  action: string;
+}
+
+/**
+ * Use this method to get a list of profile pictures for a user. Returns a 
+ * UserProfilePhotos object.
+ * @see https://core.telegram.org/bots/api#userprofilephotos
+ */
+export interface GetUserProfilePhotos {
+  /**
+   * Unique identifier of the target user
+   */
+  user_id: number;
+
+  /**
+   * Sequential number of the first photo to be returned. By default, all 
+   * photos are returned.
+   */
+  offset?: number;
+
+  /**
+   * Limits the number of photos to be retrieved. Values between 1-100 are 
+   * accepted. Defaults to 100.
+   */
+  limit?: number;
+}
+
+/**
+ * Use this method to get basic info about a file and prepare it for 
+ * downloading. For the moment, bots can download files of up to 20MB in 
+ * size. On success, a File object is returned. The file can then be 
+ * downloaded via the link 
+ * https://api.telegram.org/file/bot<token>/<file_path>, where <file_path> 
+ * is taken from the response. It is guaranteed that the link will be valid 
+ * for at least 1 hour. When the link expires, a new one can be requested 
+ * by calling getFile again.
+ * @see https://core.telegram.org/bots/api#file
+ * @see https://core.telegram.org/bots/api#getfile
+ */
+export interface GetFile {
+  /**
+   * File identifier to get info about
+   */
+  file_id: string;
+}
+
+/**
+ * Use this method to kick a user from a group, a supergroup or a channel. 
+ * In the case of supergroups and channels, the user will not be able to 
+ * return to the group on their own using invite links, etc., unless 
+ * unbanned first. The bot must be an administrator in the chat for this to 
+ * work and must have the appropriate admin rights. Returns True on success.
+ * @see https://core.telegram.org/bots/api#unbanchatmember
+ */
+export interface KickChatMember {
+  /**
+   * Unique identifier for the target group or username of the target 
+   * supergroup or channel (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Unique identifier of the target user
+   */
+  user_id: number;
+
+  /**
+   * Date when the user will be unbanned, unix time. If user is banned for 
+   * more than 366 days or less than 30 seconds from the current time they 
+   * are considered to be banned forever
+   */
+  until_date?: number;
+}
+
+/**
+ * Use this method to unban a previously kicked user in a supergroup or 
+ * channel. The user will not return to the group or channel automatically, 
+ * but will be able to join via link, etc. The bot must be an administrator 
+ * for this to work. Returns True on success.
+ */
+export interface UnbanChatMember {
+  /**
+   * Unique identifier for the target group or username of the target 
+   * supergroup or channel (in the format @username)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Unique identifier of the target user
+   */
+  user_id: number;
+}
+
+/**
+ * Use this method to restrict a user in a supergroup. The bot must be an 
+ * administrator in the supergroup for this to work and must have the 
+ * appropriate admin rights. Pass True for all permissions to lift 
+ * restrictions from a user. Returns True on success.
+ */
+export interface RestrictChatMember {
+  /**
+   * Unique identifier for the target chat or username of the target 
+   * supergroup (in the format @supergroupusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Unique identifier of the target user
+   */
+  user_id: number;
+
+  /**
+   * A JSON-serialized object for new user permissions
+   */
+  permissions: ChatPermissions;
+
+  /**
+   * Date when restrictions will be lifted for the user, unix time. If user 
+   * is restricted for more than 366 days or less than 30 seconds from the 
+   * current time, they are considered to be restricted forever
+   */
+  until_date?: number;
+}
+
+/**
+ * Use this method to promote or demote a user in a supergroup or a 
+ * channel. The bot must be an administrator in the chat for this to work 
+ * and must have the appropriate admin rights. Pass False for all boolean 
+ * parameters to demote a user. Returns True on success.
+ */
+export interface PromoteChatMember {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Unique identifier of the target user
+   */
+  user_id: number;
+
+  /**
+   * Pass True, if the administrator can change chat title, photo and other settings
+   */
+  can_change_info?: boolean;
+
+  /**
+   * Pass True, if the administrator can create channel posts, channels only
+   */
+  can_post_messages?: boolean;
+
+  /**
+   * Pass True, if the administrator can edit messages of other users and can 
+   * pin messages, channels only
+   */
+  can_edit_messages?: boolean;
+
+  /**
+   * Pass True, if the administrator can delete messages of other users
+   */
+  can_delete_messages?: boolean;
+
+  /**
+   * Pass True, if the administrator can invite new users to the chat
+   */
+  can_invite_users?: boolean;
+
+  /**
+   * Pass True, if the administrator can restrict, ban or unban chat members
+   */
+  can_restrict_members?: boolean;
+
+  /**
+   * Pass True, if the administrator can pin messages, supergroups only
+   */
+  can_pin_messages?: boolean;
+
+  /**
+   * Pass True, if the administrator can add new administrators with a subset 
+   * of their own privileges or demote administrators that he has promoted, 
+   * directly or indirectly (promoted by administrators that were appointed 
+   * by him)
+   */
+  can_promote_members?: boolean;
+}
+
+/**
+ * Use this method to set a custom title for an administrator in a 
+ * supergroup promoted by the bot. Returns True on success.
+ */
+export interface SetChatAdministratorCustomTitle {
+  /**
+   * Unique identifier for the target chat or username of the target 
+   * supergroup (in the format @supergroupusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Unique identifier of the target user
+   */
+  user_id: number;
+
+  /**
+   * New custom title for the administrator; 0-16 characters, emoji are not allowed
+   */
+  custom_title: string;
+}
+
+/**
+ * Use this method to set default chat permissions for all members. The bot 
+ * must be an administrator in the group or a supergroup for this to work 
+ * and must have the can_restrict_members admin rights. Returns True on success.
+ */
+export interface SetChatPermissions {
+  /**
+   * Unique identifier for the target chat or username of the target 
+   * supergroup (in the format @supergroupusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * New default chat permissions
+   */
+  permissions: ChatPermissions;
+}
+
+/**
+ * Use this method to generate a new invite link for a chat; any previously 
+ * generated link is revoked. The bot must be an administrator in the chat 
+ * for this to work and must have the appropriate admin rights. Returns the 
+ * new invite link as String on success.
+ */
+export interface ExportChatInviteLink {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+}
+
+/**
+ * Use this method to set a new profile photo for the chat. Photos can't be 
+ * changed for private chats. The bot must be an administrator in the chat 
+ * for this to work and must have the appropriate admin rights. Returns 
+ * True on success.
+ */
+export interface SetChatPhoto {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * New chat photo, uploaded using multipart/form-data
+   */
+  photo: InputFile;
+}
+
+/**
+ * Use this method to delete a chat photo. Photos can't be changed for 
+ * private chats. The bot must be an administrator in the chat for this to 
+ * work and must have the appropriate admin rights. Returns True on success.
+ */
+export interface DeleteChatPhoto {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+}
+
+/**
+ * Use this method to change the title of a chat. Titles can't be changed 
+ * for private chats. The bot must be an administrator in the chat for this 
+ * to work and must have the appropriate admin rights. Returns True on success.
+ */
+export interface SetChatTitle {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * New chat title, 1-255 characters
+   */
+  title: string;
+}
+
+/**
+ * Use this method to change the description of a group, a supergroup or a 
+ * channel. The bot must be an administrator in the chat for this to work 
+ * and must have the appropriate admin rights. Returns True on success.
+ */
+export interface SetChatDescription {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * New chat description, 0-255 characters
+   */
+  description?: string;
+}
+
+/**
+ * Use this method to pin a message in a group, a supergroup, or a channel. 
+ * The bot must be an administrator in the chat for this to work and must 
+ * have the 'can_pin_messages' admin right in the supergroup or 
+ * 'can_edit_messages' admin right in the channel. Returns True on success.
+ */
+export interface PinChatMessage {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Identifier of a message to pin
+   */
+  message_id: number;
+
+  /**
+   * Pass True, if it is not necessary to send a notification to all chat 
+   * members about the new pinned message. Notifications are always disabled 
+   * in channels.
+   */
+  disable_notification?: boolean;
+}
+
+/**
+ * Use this method to unpin a message in a group, a supergroup, or a 
+ * channel. The bot must be an administrator in the chat for this to work 
+ * and must have the 'can_pin_messages' admin right in the supergroup or 
+ * 'can_edit_messages' admin right in the channel. Returns True on success.
+ */
+export interface UnpinChatMessage {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+}
+
+/**
+ * Use this method for your bot to leave a group, supergroup or channel. 
+ * Returns True on success.
+ */
+export interface LeaveChat {
+  /**
+   * Unique identifier for the target chat or username of the target 
+   * supergroup or channel (in the format @channelusername)
+   */
+  chat_id: (number | string);
+}
+
+/**
+ * Use this method to get up to date information about the chat (current 
+ * name of the user for one-on-one conversations, current username of a 
+ * user, group or channel, etc.). Returns a Chat object on success.
+ * @see https://core.telegram.org/bots/api#chat
+ */
+export interface GetChat {
+  /**
+   * Unique identifier for the target chat or username of the target 
+   * supergroup or channel (in the format @channelusername)
+   */
+  chat_id: (number | string);
+}
+
+/**
+ * Use this method to get a list of administrators in a chat. On success, 
+ * returns an Array of ChatMember objects that contains information about 
+ * all chat administrators except other bots. If the chat is a group or a 
+ * supergroup and no administrators were appointed, only the creator will 
+ * be returned.
+ * @see https://core.telegram.org/bots/api#chatmember
+ */
+export interface GetChatAdministrators {
+  /**
+   * Unique identifier for the target chat or username of the target 
+   * supergroup or channel (in the format @channelusername)
+   */
+  chat_id: (number | string);
+}
+
+/**
+ * Use this method to get the number of members in a chat. Returns Int on success.
+ */
+export interface GetChatMembersCount {
+  /**
+   * Unique identifier for the target chat or username of the target 
+   * supergroup or channel (in the format @channelusername)
+   */
+  chat_id: (number | string);
+}
+
+/**
+ * Use this method to get information about a member of a chat. Returns a 
+ * ChatMember object on success.
+ * @see https://core.telegram.org/bots/api#chatmember
+ */
+export interface GetChatMember {
+  /**
+   * Unique identifier for the target chat or username of the target 
+   * supergroup or channel (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Unique identifier of the target user
+   */
+  user_id: number;
+}
+
+/**
+ * Use this method to set a new group sticker set for a supergroup. The bot 
+ * must be an administrator in the chat for this to work and must have the 
+ * appropriate admin rights. Use the field can_set_sticker_set optionally 
+ * returned in getChat requests to check if the bot can use this method. 
+ * Returns True on success.
+ * @see https://core.telegram.org/bots/api#getchat
+ */
+export interface SetChatStickerSet {
+  /**
+   * Unique identifier for the target chat or username of the target 
+   * supergroup (in the format @supergroupusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Name of the sticker set to be set as the group sticker set
+   */
+  sticker_set_name: string;
+}
+
+/**
+ * Use this method to delete a group sticker set from a supergroup. The bot 
+ * must be an administrator in the chat for this to work and must have the 
+ * appropriate admin rights. Use the field can_set_sticker_set optionally 
+ * returned in getChat requests to check if the bot can use this method. 
+ * Returns True on success.
+ * @see https://core.telegram.org/bots/api#getchat
+ */
+export interface DeleteChatStickerSet {
+  /**
+   * Unique identifier for the target chat or username of the target 
+   * supergroup (in the format @supergroupusername)
+   */
+  chat_id: (number | string);
+}
+
+/**
+ * Use this method to send answers to callback queries sent from inline 
+ * keyboards. The answer will be displayed to the user as a notification at 
+ * the top of the chat screen or as an alert. On success, True is returned.
+ * @see https://core.telegram.org/bots/api/bots#inline-keyboards-and-on-the-fly-updating
+ */
+export interface AnswerCallbackQuery {
+  /**
+   * Unique identifier for the query to be answered
+   */
+  callback_query_id: string;
+
+  /**
+   * Text of the notification. If not specified, nothing will be shown to the 
+   * user, 0-200 characters
+   */
+  text?: string;
+
+  /**
+   * If true, an alert will be shown by the client instead of a notification 
+   * at the top of the chat screen. Defaults to false.
+   */
+  show_alert?: boolean;
+
+  /**
+   * URL that will be opened by the user's client. If you have created a Game 
+   * and accepted the conditions via @Botfather, specify the URL that opens 
+   * your game — note that this will only work if the query comes from a 
+   * callback_game button.Otherwise, you may use links like 
+   * t.me/your_bot?start=XXXX that open your bot with a parameter.
+   * @see https://core.telegram.org/bots/api#game
+   * @see https://t.me/botfather
+   * @see https://core.telegram.org/bots/api#inlinekeyboardbutton
+   */
+  url?: string;
+
+  /**
+   * The maximum amount of time in seconds that the result of the callback 
+   * query may be cached client-side. Telegram apps will support caching 
+   * starting in version 3.14. Defaults to 0.
+   */
+  cache_time?: number;
+}
+
+/**
+ * Use this method to change the list of the bot's commands. Returns True 
+ * on success.
+ */
+export interface SetMyCommands {
+  /**
+   * A JSON-serialized list of bot commands to be set as the list of the 
+   * bot's commands. At most 100 commands can be specified.
+   */
+  commands: BotCommand[];
+}
+
+/**
+ * Use this method to edit text and game messages. On success, if edited 
+ * message is sent by the bot, the edited Message is returned, otherwise 
+ * True is returned.
+ * @see https://core.telegram.org/bots/api#games
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface EditMessageText {
+  /**
+   * Required if inline_message_id is not specified. Unique identifier for 
+   * the target chat or username of the target channel (in the format @channelusername)
+   */
+  chat_id?: (number | string);
+
+  /**
+   * Required if inline_message_id is not specified. Identifier of the 
+   * message to edit
+   */
+  message_id?: number;
+
+  /**
+   * Required if chat_id and message_id are not specified. Identifier of the 
+   * inline message
+   */
+  inline_message_id?: string;
+
+  /**
+   * New text of the message, 1-4096 characters after entities parsing
+   */
+  text: string;
+
+  /**
+   * Mode for parsing entities in the message text. See formatting options 
+   * for more details.
+   * @see https://core.telegram.org/bots/api#formatting-options
+   */
+  parse_mode?: string;
+
+  /**
+   * Disables link previews for links in this message
+   */
+  disable_web_page_preview?: boolean;
+
+  /**
+   * A JSON-serialized object for an inline keyboard.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   */
+  reply_markup?: InlineKeyboardMarkup;
+}
+
+/**
+ * Use this method to edit captions of messages. On success, if edited 
+ * message is sent by the bot, the edited Message is returned, otherwise 
+ * True is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface EditMessageCaption {
+  /**
+   * Required if inline_message_id is not specified. Unique identifier for 
+   * the target chat or username of the target channel (in the format @channelusername)
+   */
+  chat_id?: (number | string);
+
+  /**
+   * Required if inline_message_id is not specified. Identifier of the 
+   * message to edit
+   */
+  message_id?: number;
+
+  /**
+   * Required if chat_id and message_id are not specified. Identifier of the 
+   * inline message
+   */
+  inline_message_id?: string;
+
+  /**
+   * New caption of the message, 0-1024 characters after entities parsing
+   */
+  caption?: string;
+
+  /**
+   * Mode for parsing entities in the message caption. See formatting options 
+   * for more details.
+   * @see https://core.telegram.org/bots/api#formatting-options
+   */
+  parse_mode?: string;
+
+  /**
+   * A JSON-serialized object for an inline keyboard.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   */
+  reply_markup?: InlineKeyboardMarkup;
+}
+
+/**
+ * Use this method to edit animation, audio, document, photo, or video 
+ * messages. If a message is a part of a message album, then it can be 
+ * edited only to a photo or a video. Otherwise, message type can be 
+ * changed arbitrarily. When inline message is edited, new file can't be 
+ * uploaded. Use previously uploaded file via its file_id or specify a URL. 
+ * On success, if the edited message was sent by the bot, the edited 
+ * Message is returned, otherwise True is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface EditMessageMedia {
+  /**
+   * Required if inline_message_id is not specified. Unique identifier for 
+   * the target chat or username of the target channel (in the format @channelusername)
+   */
+  chat_id?: (number | string);
+
+  /**
+   * Required if inline_message_id is not specified. Identifier of the 
+   * message to edit
+   */
+  message_id?: number;
+
+  /**
+   * Required if chat_id and message_id are not specified. Identifier of the 
+   * inline message
+   */
+  inline_message_id?: string;
+
+  /**
+   * A JSON-serialized object for a new media content of the message
+   */
+  media: InputMedia;
+
+  /**
+   * A JSON-serialized object for a new inline keyboard.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   */
+  reply_markup?: InlineKeyboardMarkup;
+}
+
+/**
+ * Use this method to edit only the reply markup of messages. On success, 
+ * if edited message is sent by the bot, the edited Message is returned, 
+ * otherwise True is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface EditMessageReplyMarkup {
+  /**
+   * Required if inline_message_id is not specified. Unique identifier for 
+   * the target chat or username of the target channel (in the format @channelusername)
+   */
+  chat_id?: (number | string);
+
+  /**
+   * Required if inline_message_id is not specified. Identifier of the 
+   * message to edit
+   */
+  message_id?: number;
+
+  /**
+   * Required if chat_id and message_id are not specified. Identifier of the 
+   * inline message
+   */
+  inline_message_id?: string;
+
+  /**
+   * A JSON-serialized object for an inline keyboard.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   */
+  reply_markup?: InlineKeyboardMarkup;
+}
+
+/**
+ * Use this method to stop a poll which was sent by the bot. On success, 
+ * the stopped Poll with the final results is returned.
+ * @see https://core.telegram.org/bots/api#poll
+ */
+export interface StopPoll {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Identifier of the original message with the poll
+   */
+  message_id: number;
+
+  /**
+   * A JSON-serialized object for a new message inline keyboard.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   */
+  reply_markup?: InlineKeyboardMarkup;
+}
+
+/**
+ * Use this method to delete a message, including service messages, with 
+ * the following limitations:- A message can only be deleted if it was sent 
+ * less than 48 hours ago.- A dice message in a private chat can only be 
+ * deleted if it was sent more than 24 hours ago.- Bots can delete outgoing 
+ * messages in private chats, groups, and supergroups.- Bots can delete 
+ * incoming messages in private chats.- Bots granted can_post_messages 
+ * permissions can delete outgoing messages in channels.- If the bot is an 
+ * administrator of a group, it can delete any message there.- If the bot 
+ * has can_delete_messages permission in a supergroup or a channel, it can 
+ * delete any message there.Returns True on success.
+ */
+export interface DeleteMessage {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Identifier of the message to delete
+   */
+  message_id: number;
 }
 
 /**
@@ -1614,9 +3966,15 @@ export interface InputMediaDocument {
  */
 export interface Sticker {
   /**
-   * Unique identifier for this file
+   * Identifier for this file, which can be used to download or reuse the file
    */
   file_id: string;
+
+  /**
+   * Unique identifier for this file, which is supposed to be the same over 
+   * time and for different bots. Can't be used to download or reuse the file.
+   */
+  file_unique_id: string;
 
   /**
    * Sticker width
@@ -1628,13 +3986,14 @@ export interface Sticker {
    */
   height: number;
 
-  /** 
-   * True, if the sticker is animated 
+  /**
+   * True, if the sticker is animated
+   * @see https://telegram.org/blog/animated-stickers
    */
   is_animated: boolean;
-  
+
   /**
-   * Sticker thumbnail in the .webp or .jpg format
+   * Sticker thumbnail in the .WEBP or .JPG format
    */
   thumb?: PhotoSize;
 
@@ -1674,6 +4033,12 @@ export interface StickerSet {
   title: string;
 
   /**
+   * True, if the sticker set contains animated stickers
+   * @see https://telegram.org/blog/animated-stickers
+   */
+  is_animated: boolean;
+
+  /**
    * True, if the sticker set contains masks
    */
   contains_masks: boolean;
@@ -1682,6 +4047,11 @@ export interface StickerSet {
    * List of all set stickers
    */
   stickers: Sticker[];
+
+  /**
+   * Sticker set thumbnail in the .WEBP or .TGS format
+   */
+  thumb?: PhotoSize;
 }
 
 /**
@@ -1716,6 +4086,246 @@ export interface MaskPosition {
 }
 
 /**
+ * Use this method to send static .WEBP or animated .TGS stickers. On 
+ * success, the sent Message is returned.
+ * @see https://telegram.org/blog/animated-stickers
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendSticker {
+  /**
+   * Unique identifier for the target chat or username of the target channel 
+   * (in the format @channelusername)
+   */
+  chat_id: (number | string);
+
+  /**
+   * Sticker to send. Pass a file_id as String to send a file that exists on 
+   * the Telegram servers (recommended), pass an HTTP URL as a String for 
+   * Telegram to get a .WEBP file from the Internet, or upload a new one 
+   * using multipart/form-data. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  sticker: (InputFile | string);
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * Additional interface options. A JSON-serialized object for an inline 
+   * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+   * or to force a reply from the user.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   * @see https://core.telegram.org/bots#keyboards
+   */
+  reply_markup?: (InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply);
+}
+
+/**
+ * Use this method to get a sticker set. On success, a StickerSet object is returned.
+ * @see https://core.telegram.org/bots/api#stickerset
+ */
+export interface GetStickerSet {
+  /**
+   * Name of the sticker set
+   */
+  name: string;
+}
+
+/**
+ * Use this method to upload a .PNG file with a sticker for later use in 
+ * createNewStickerSet and addStickerToSet methods (can be used multiple 
+ * times). Returns the uploaded File on success.
+ * @see https://core.telegram.org/bots/api#file
+ */
+export interface UploadStickerFile {
+  /**
+   * User identifier of sticker file owner
+   */
+  user_id: number;
+
+  /**
+   * PNG image with the sticker, must be up to 512 kilobytes in size, 
+   * dimensions must not exceed 512px, and either width or height must be 
+   * exactly 512px. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  png_sticker: InputFile;
+}
+
+/**
+ * Use this method to create a new sticker set owned by a user. The bot 
+ * will be able to edit the sticker set thus created. You must use exactly 
+ * one of the fields png_sticker or tgs_sticker. Returns True on success.
+ */
+export interface CreateNewStickerSet {
+  /**
+   * User identifier of created sticker set owner
+   */
+  user_id: number;
+
+  /**
+   * Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., 
+   * animals). Can contain only english letters, digits and underscores. Must 
+   * begin with a letter, can't contain consecutive underscores and must end 
+   * in “_by_<bot username>”. <bot_username> is case insensitive. 1-64 characters.
+   */
+  name: string;
+
+  /**
+   * Sticker set title, 1-64 characters
+   */
+  title: string;
+
+  /**
+   * PNG image with the sticker, must be up to 512 kilobytes in size, 
+   * dimensions must not exceed 512px, and either width or height must be 
+   * exactly 512px. Pass a file_id as a String to send a file that already 
+   * exists on the Telegram servers, pass an HTTP URL as a String for 
+   * Telegram to get a file from the Internet, or upload a new one using 
+   * multipart/form-data. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  png_sticker?: (InputFile | string);
+
+  /**
+   * TGS animation with the sticker, uploaded using multipart/form-data. See 
+   * https://core.telegram.org/animated_stickers#technical-requirements for 
+   * technical requirements
+   * @see https://core.telegram.org/animated_stickers#technical-requirements
+   */
+  tgs_sticker?: InputFile;
+
+  /**
+   * One or more emoji corresponding to the sticker
+   */
+  emojis: string;
+
+  /**
+   * Pass True, if a set of mask stickers should be created
+   */
+  contains_masks?: boolean;
+
+  /**
+   * A JSON-serialized object for position where the mask should be placed on faces
+   */
+  mask_position?: MaskPosition;
+}
+
+/**
+ * Use this method to add a new sticker to a set created by the bot. You 
+ * must use exactly one of the fields png_sticker or tgs_sticker. Animated 
+ * stickers can be added to animated sticker sets and only to them. 
+ * Animated sticker sets can have up to 50 stickers. Static sticker sets 
+ * can have up to 120 stickers. Returns True on success.
+ */
+export interface AddStickerToSet {
+  /**
+   * User identifier of sticker set owner
+   */
+  user_id: number;
+
+  /**
+   * Sticker set name
+   */
+  name: string;
+
+  /**
+   * PNG image with the sticker, must be up to 512 kilobytes in size, 
+   * dimensions must not exceed 512px, and either width or height must be 
+   * exactly 512px. Pass a file_id as a String to send a file that already 
+   * exists on the Telegram servers, pass an HTTP URL as a String for 
+   * Telegram to get a file from the Internet, or upload a new one using 
+   * multipart/form-data. More info on Sending Files »
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  png_sticker?: (InputFile | string);
+
+  /**
+   * TGS animation with the sticker, uploaded using multipart/form-data. See 
+   * https://core.telegram.org/animated_stickers#technical-requirements for 
+   * technical requirements
+   * @see https://core.telegram.org/animated_stickers#technical-requirements
+   */
+  tgs_sticker?: InputFile;
+
+  /**
+   * One or more emoji corresponding to the sticker
+   */
+  emojis: string;
+
+  /**
+   * A JSON-serialized object for position where the mask should be placed on faces
+   */
+  mask_position?: MaskPosition;
+}
+
+/**
+ * Use this method to move a sticker in a set created by the bot to a 
+ * specific position. Returns True on success.
+ */
+export interface SetStickerPositionInSet {
+  /**
+   * File identifier of the sticker
+   */
+  sticker: string;
+
+  /**
+   * New sticker position in the set, zero-based
+   */
+  position: number;
+}
+
+/**
+ * Use this method to delete a sticker from a set created by the bot. 
+ * Returns True on success.
+ */
+export interface DeleteStickerFromSet {
+  /**
+   * File identifier of the sticker
+   */
+  sticker: string;
+}
+
+/**
+ * Use this method to set the thumbnail of a sticker set. Animated 
+ * thumbnails can be set for animated sticker sets only. Returns True on success.
+ */
+export interface SetStickerSetThumb {
+  /**
+   * Sticker set name
+   */
+  name: string;
+
+  /**
+   * User identifier of the sticker set owner
+   */
+  user_id: number;
+
+  /**
+   * A PNG image with the thumbnail, must be up to 128 kilobytes in size and 
+   * have width and height exactly 100px, or a TGS animation with the 
+   * thumbnail up to 32 kilobytes in size; see 
+   * https://core.telegram.org/animated_stickers#technical-requirements for 
+   * animated sticker technical requirements. Pass a file_id as a String to 
+   * send a file that already exists on the Telegram servers, pass an HTTP 
+   * URL as a String for Telegram to get a file from the Internet, or upload 
+   * a new one using multipart/form-data. More info on Sending Files ». 
+   * Animated sticker set thumbnail can't be uploaded via HTTP URL.
+   * @see https://core.telegram.org/animated_stickers#technical-requirements
+   * @see https://core.telegram.org/bots/api#sending-files
+   */
+  thumb?: (InputFile | string);
+}
+
+/**
  * This object represents an incoming inline query. When the user sends an 
  * empty query, your bot could return some default or trending results.
  */
@@ -1736,7 +4346,7 @@ export interface InlineQuery {
   location?: Location;
 
   /**
-   * Text of the query (up to 512 characters)
+   * Text of the query (up to 256 characters)
    */
   query: string;
 
@@ -1744,6 +4354,66 @@ export interface InlineQuery {
    * Offset of the results to be returned, can be controlled by the bot
    */
   offset: string;
+}
+
+/**
+ * Use this method to send answers to an inline query. On success, True is 
+ * returned.No more than 50 results per query are allowed.
+ */
+export interface AnswerInlineQuery {
+  /**
+   * Unique identifier for the answered query
+   */
+  inline_query_id: string;
+
+  /**
+   * A JSON-serialized array of results for the inline query
+   */
+  results: InlineQueryResult[];
+
+  /**
+   * The maximum amount of time in seconds that the result of the inline 
+   * query may be cached on the server. Defaults to 300.
+   */
+  cache_time?: number;
+
+  /**
+   * Pass True, if results may be cached on the server side only for the user 
+   * that sent the query. By default, results may be returned to any user who 
+   * sends the same query
+   */
+  is_personal?: boolean;
+
+  /**
+   * Pass the offset that a client should send in the next query with the 
+   * same text to receive more results. Pass an empty string if there are no 
+   * more results or if you don't support pagination. Offset length can't 
+   * exceed 64 bytes.
+   */
+  next_offset?: string;
+
+  /**
+   * If passed, clients will display a button with specified text that 
+   * switches the user to a private chat with the bot and sends the bot a 
+   * start message with the parameter switch_pm_parameter
+   */
+  switch_pm_text?: string;
+
+  /**
+   * Deep-linking parameter for the /start message sent to the bot when user 
+   * presses the switch button. 1-64 characters, only A-Z, a-z, 0-9, _ and - 
+   * are allowed.Example: An inline bot that sends YouTube videos can ask the 
+   * user to connect the bot to their YouTube account to adapt search results 
+   * accordingly. To do this, it displays a 'Connect your YouTube account' 
+   * button above the results, or even before showing any. The user presses 
+   * the button, switches to a private chat with the bot and, in doing so, 
+   * passes a start parameter that instructs the bot to return an oauth link. 
+   * Once done, the bot can offer a switch_inline button so that the user can 
+   * easily return to the chat where they wanted to use the bot's inline capabilities.
+   * @see https://core.telegram.org/bots/api/bots#deep-linking
+   * @see https://core.telegram.org/bots/api#inlinekeyboardmarkup
+   */
+  switch_pm_parameter?: string;
 }
 
 /**
@@ -1856,15 +4526,13 @@ export interface InlineQueryResultPhoto {
   description?: string;
 
   /**
-   * Caption of the photo to be sent, 0-200 characters
+   * Caption of the photo to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the photo caption. See formatting options 
+   * for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -1919,9 +4587,15 @@ export interface InlineQueryResultGif {
   gif_duration?: number;
 
   /**
-   * URL of the static thumbnail for the result (jpeg or gif)
+   * URL of the static (JPEG or GIF) or animated (MPEG4) thumbnail for the result
    */
   thumb_url: string;
+
+  /**
+   * MIME type of the thumbnail, must be one of “image/jpeg”, “image/gif”, or 
+   * “video/mp4”. Defaults to “image/jpeg”
+   */
+  thumb_mime_type?: string;
 
   /**
    * Title for the result
@@ -1929,15 +4603,13 @@ export interface InlineQueryResultGif {
   title?: string;
 
   /**
-   * Caption of the GIF file to be sent, 0-200 characters
+   * Caption of the GIF file to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the caption. See formatting options for 
+   * more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -1992,9 +4664,15 @@ export interface InlineQueryResultMpeg4Gif {
   mpeg4_duration?: number;
 
   /**
-   * URL of the static thumbnail (jpeg or gif) for the result
+   * URL of the static (JPEG or GIF) or animated (MPEG4) thumbnail for the result
    */
   thumb_url: string;
+
+  /**
+   * MIME type of the thumbnail, must be one of “image/jpeg”, “image/gif”, or 
+   * “video/mp4”. Defaults to “image/jpeg”
+   */
+  thumb_mime_type?: string;
 
   /**
    * Title for the result
@@ -2002,15 +4680,13 @@ export interface InlineQueryResultMpeg4Gif {
   title?: string;
 
   /**
-   * Caption of the MPEG-4 file to be sent, 0-200 characters
+   * Caption of the MPEG-4 file to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the caption. See formatting options for 
+   * more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -2065,15 +4741,13 @@ export interface InlineQueryResultVideo {
   title: string;
 
   /**
-   * Caption of the video to be sent, 0-200 characters
+   * Caption of the video to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the video caption. See formatting options 
+   * for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -2113,7 +4787,7 @@ export interface InlineQueryResultVideo {
 }
 
 /**
- * Represents a link to an mp3 audio file. By default, this audio file will 
+ * Represents a link to an MP3 audio file. By default, this audio file will 
  * be sent by the user. Alternatively, you can use input_message_content to 
  * send a message with the specified content instead of the audio.
  */
@@ -2139,15 +4813,13 @@ export interface InlineQueryResultAudio {
   title: string;
 
   /**
-   * Caption, 0-200 characters
+   * Caption, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the audio caption. See formatting options 
+   * for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -2175,7 +4847,7 @@ export interface InlineQueryResultAudio {
 }
 
 /**
- * Represents a link to a voice recording in an .ogg container encoded with 
+ * Represents a link to a voice recording in an .OGG container encoded with 
  * OPUS. By default, this voice recording will be sent by the user. 
  * Alternatively, you can use input_message_content to send a message with 
  * the specified content instead of the the voice message.
@@ -2202,15 +4874,13 @@ export interface InlineQueryResultVoice {
   title: string;
 
   /**
-   * Caption, 0-200 characters
+   * Caption, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the voice message caption. See formatting 
+   * options for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -2256,15 +4926,13 @@ export interface InlineQueryResultDocument {
   title: string;
 
   /**
-   * Caption of the document to be sent, 0-200 characters
+   * Caption of the document to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the document caption. See formatting 
+   * options for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -2572,15 +5240,13 @@ export interface InlineQueryResultCachedPhoto {
   description?: string;
 
   /**
-   * Caption of the photo to be sent, 0-200 characters
+   * Caption of the photo to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the photo caption. See formatting options 
+   * for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -2626,15 +5292,13 @@ export interface InlineQueryResultCachedGif {
   title?: string;
 
   /**
-   * Caption of the GIF file to be sent, 0-200 characters
+   * Caption of the GIF file to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the caption. See formatting options for 
+   * more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -2680,15 +5344,13 @@ export interface InlineQueryResultCachedMpeg4Gif {
   title?: string;
 
   /**
-   * Caption of the MPEG-4 file to be sent, 0-200 characters
+   * Caption of the MPEG-4 file to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the caption. See formatting options for 
+   * more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -2772,15 +5434,13 @@ export interface InlineQueryResultCachedDocument {
   description?: string;
 
   /**
-   * Caption of the document to be sent, 0-200 characters
+   * Caption of the document to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the document caption. See formatting 
+   * options for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -2830,15 +5490,13 @@ export interface InlineQueryResultCachedVideo {
   description?: string;
 
   /**
-   * Caption of the video to be sent, 0-200 characters
+   * Caption of the video to be sent, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the video caption. See formatting options 
+   * for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -2883,15 +5541,13 @@ export interface InlineQueryResultCachedVoice {
   title: string;
 
   /**
-   * Caption, 0-200 characters
+   * Caption, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the voice message caption. See formatting 
+   * options for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -2909,7 +5565,7 @@ export interface InlineQueryResultCachedVoice {
 }
 
 /**
- * Represents a link to an mp3 audio file stored on the Telegram servers. 
+ * Represents a link to an MP3 audio file stored on the Telegram servers. 
  * By default, this audio file will be sent by the user. Alternatively, you 
  * can use input_message_content to send a message with the specified 
  * content instead of the audio.
@@ -2931,15 +5587,13 @@ export interface InlineQueryResultCachedAudio {
   audio_file_id: string;
 
   /**
-   * Caption, 0-200 characters
+   * Caption, 0-1024 characters after entities parsing
    */
   caption?: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in the media caption.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the audio caption. See formatting options 
+   * for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -2968,10 +5622,8 @@ export interface InputTextMessageContent {
   message_text: string;
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-   * fixed-width text or inline URLs in your bot's message.
-   * @see https://core.telegram.org/bots/api#markdown-style
-   * @see https://core.telegram.org/bots/api#html-style
+   * Mode for parsing entities in the message text. See formatting options 
+   * for more details.
    * @see https://core.telegram.org/bots/api#formatting-options
    */
   parse_mode?: string;
@@ -3106,6 +5758,204 @@ export interface ChosenInlineResult {
    * The query that was used to obtain the result
    */
   query: string;
+}
+
+/**
+ * Use this method to send invoices. On success, the sent Message is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendInvoice {
+  /**
+   * Unique identifier for the target private chat
+   */
+  chat_id: number;
+
+  /**
+   * Product name, 1-32 characters
+   */
+  title: string;
+
+  /**
+   * Product description, 1-255 characters
+   */
+  description: string;
+
+  /**
+   * Bot-defined invoice payload, 1-128 bytes. This will not be displayed to 
+   * the user, use for your internal processes.
+   */
+  payload: string;
+
+  /**
+   * Payments provider token, obtained via Botfather
+   * @see https://t.me/botfather
+   */
+  provider_token: string;
+
+  /**
+   * Unique deep-linking parameter that can be used to generate this invoice 
+   * when used as a start parameter
+   */
+  start_parameter: string;
+
+  /**
+   * Three-letter ISO 4217 currency code, see more on currencies
+   * @see https://core.telegram.org/bots/api/bots/payments#supported-currencies
+   */
+  currency: string;
+
+  /**
+   * Price breakdown, a JSON-serialized list of components (e.g. product 
+   * price, tax, discount, delivery cost, delivery tax, bonus, etc.)
+   */
+  prices: LabeledPrice[];
+
+  /**
+   * A JSON-serialized data about the invoice, which will be shared with the 
+   * payment provider. A detailed description of required fields should be 
+   * provided by the payment provider.
+   */
+  provider_data?: string;
+
+  /**
+   * URL of the product photo for the invoice. Can be a photo of the goods or 
+   * a marketing image for a service. People like it better when they see 
+   * what they are paying for.
+   */
+  photo_url?: string;
+
+  /**
+   * Photo size
+   */
+  photo_size?: number;
+
+  /**
+   * Photo width
+   */
+  photo_width?: number;
+
+  /**
+   * Photo height
+   */
+  photo_height?: number;
+
+  /**
+   * Pass True, if you require the user's full name to complete the order
+   */
+  need_name?: boolean;
+
+  /**
+   * Pass True, if you require the user's phone number to complete the order
+   */
+  need_phone_number?: boolean;
+
+  /**
+   * Pass True, if you require the user's email address to complete the order
+   */
+  need_email?: boolean;
+
+  /**
+   * Pass True, if you require the user's shipping address to complete the order
+   */
+  need_shipping_address?: boolean;
+
+  /**
+   * Pass True, if user's phone number should be sent to provider
+   */
+  send_phone_number_to_provider?: boolean;
+
+  /**
+   * Pass True, if user's email address should be sent to provider
+   */
+  send_email_to_provider?: boolean;
+
+  /**
+   * Pass True, if the final price depends on the shipping method
+   */
+  is_flexible?: boolean;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * A JSON-serialized object for an inline keyboard. If empty, one 'Pay 
+   * total price' button will be shown. If not empty, the first button must 
+   * be a Pay button.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   */
+  reply_markup?: InlineKeyboardMarkup;
+}
+
+/**
+ * If you sent an invoice requesting a shipping address and the parameter 
+ * is_flexible was specified, the Bot API will send an Update with a 
+ * shipping_query field to the bot. Use this method to reply to shipping 
+ * queries. On success, True is returned.
+ * @see https://core.telegram.org/bots/api#update
+ */
+export interface AnswerShippingQuery {
+  /**
+   * Unique identifier for the query to be answered
+   */
+  shipping_query_id: string;
+
+  /**
+   * Specify True if delivery to the specified address is possible and False 
+   * if there are any problems (for example, if delivery to the specified 
+   * address is not possible)
+   */
+  ok: boolean;
+
+  /**
+   * Required if ok is True. A JSON-serialized array of available shipping options.
+   */
+  shipping_options?: ShippingOption[];
+
+  /**
+   * Required if ok is False. Error message in human readable form that 
+   * explains why it is impossible to complete the order (e.g. "Sorry, 
+   * delivery to your desired address is unavailable'). Telegram will display 
+   * this message to the user.
+   */
+  error_message?: string;
+}
+
+/**
+ * Once the user has confirmed their payment and shipping details, the Bot 
+ * API sends the final confirmation in the form of an Update with the field 
+ * pre_checkout_query. Use this method to respond to such pre-checkout 
+ * queries. On success, True is returned. Note: The Bot API must receive an 
+ * answer within 10 seconds after the pre-checkout query was sent.
+ * @see https://core.telegram.org/bots/api#update
+ */
+export interface AnswerPreCheckoutQuery {
+  /**
+   * Unique identifier for the query to be answered
+   */
+  pre_checkout_query_id: string;
+
+  /**
+   * Specify True if everything is alright (goods are available, etc.) and 
+   * the bot is ready to proceed with the order. Use False if there are any problems.
+   */
+  ok: boolean;
+
+  /**
+   * Required if ok is False. Error message in human readable form that 
+   * explains the reason for failure to proceed with the checkout (e.g. 
+   * "Sorry, somebody just bought the last of our amazing black T-shirts 
+   * while you were busy filling out your payment details. Please choose a 
+   * different color or garment!"). Telegram will display this message to the user.
+   */
+  error_message?: string;
 }
 
 /**
@@ -3365,9 +6215,15 @@ export interface PreCheckoutQuery {
  */
 export interface PassportFile {
   /**
-   * Unique identifier for this file
+   * Identifier for this file, which can be used to download or reuse the file
    */
   file_id: string;
+
+  /**
+   * Unique identifier for this file, which is supposed to be the same over 
+   * time and for different bots. Can't be used to download or reuse the file.
+   */
+  file_unique_id: string;
 
   /**
    * File size
@@ -3378,6 +6234,24 @@ export interface PassportFile {
    * Unix time when the file was uploaded
    */
   file_date: number;
+}
+
+/**
+ * Informs a user that some of the Telegram Passport elements they provided 
+ * contains errors. The user will not be able to re-submit their Passport 
+ * to you until the errors are fixed (the contents of the field for which 
+ * you returned the error must change). Returns True on success.
+ */
+export interface SetPassportDataErrors {
+  /**
+   * User identifier
+   */
+  user_id: number;
+
+  /**
+   * A JSON-serialized array describing the errors
+   */
+  errors: PassportElementError[];
 }
 
 /**
@@ -3551,6 +6425,128 @@ export interface PassportElementErrorFiles {
 }
 
 /**
+ * Represents an issue with one of the files that constitute the 
+ * translation of a document. The error is considered resolved when the 
+ * file changes.
+ */
+export interface PassportElementErrorTranslationFile {
+  /**
+   * Error source, must be translation_file
+   */
+  source: string;
+
+  /**
+   * Type of element of the user's Telegram Passport which has the issue, one 
+   * of “passport”, “driver_license”, “identity_card”, “internal_passport”, 
+   * “utility_bill”, “bank_statement”, “rental_agreement”, 
+   * “passport_registration”, “temporary_registration”
+   */
+  type: string;
+
+  /**
+   * Base64-encoded file hash
+   */
+  file_hash: string;
+
+  /**
+   * Error message
+   */
+  message: string;
+}
+
+/**
+ * Represents an issue with the translated version of a document. The error 
+ * is considered resolved when a file with the document translation change.
+ */
+export interface PassportElementErrorTranslationFiles {
+  /**
+   * Error source, must be translation_files
+   */
+  source: string;
+
+  /**
+   * Type of element of the user's Telegram Passport which has the issue, one 
+   * of “passport”, “driver_license”, “identity_card”, “internal_passport”, 
+   * “utility_bill”, “bank_statement”, “rental_agreement”, 
+   * “passport_registration”, “temporary_registration”
+   */
+  type: string;
+
+  /**
+   * List of base64-encoded file hashes
+   */
+  file_hashes: string[];
+
+  /**
+   * Error message
+   */
+  message: string;
+}
+
+/**
+ * Represents an issue in an unspecified place. The error is considered 
+ * resolved when new data is added.
+ */
+export interface PassportElementErrorUnspecified {
+  /**
+   * Error source, must be unspecified
+   */
+  source: string;
+
+  /**
+   * Type of element of the user's Telegram Passport which has the issue
+   */
+  type: string;
+
+  /**
+   * Base64-encoded element hash
+   */
+  element_hash: string;
+
+  /**
+   * Error message
+   */
+  message: string;
+}
+
+/**
+ * Use this method to send a game. On success, the sent Message is returned.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SendGame {
+  /**
+   * Unique identifier for the target chat
+   */
+  chat_id: number;
+
+  /**
+   * Short name of the game, serves as the unique identifier for the game. 
+   * Set up your games via Botfather.
+   * @see https://t.me/botfather
+   */
+  game_short_name: string;
+
+  /**
+   * Sends the message silently. Users will receive a notification with no sound.
+   * @see https://telegram.org/blog/channels-2-0#silent-messages
+   */
+  disable_notification?: boolean;
+
+  /**
+   * If the message is a reply, ID of the original message
+   */
+  reply_to_message_id?: number;
+
+  /**
+   * A JSON-serialized object for an inline keyboard. If empty, one 'Play 
+   * game_title' button will be shown. If not empty, the first button must 
+   * launch the game.
+   * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+   */
+  reply_markup?: InlineKeyboardMarkup;
+}
+
+/**
  * This object represents a game. Use BotFather to create and edit games, 
  * their short names will act as unique identifiers.
  */
@@ -3592,6 +6588,84 @@ export interface Game {
    * @see https://t.me/botfather
    */
   animation?: Animation;
+}
+
+/**
+ * Use this method to set the score of the specified user in a game. On 
+ * success, if the message was sent by the bot, returns the edited Message, 
+ * otherwise returns True. Returns an error, if the new score is not 
+ * greater than the user's current score in the chat and force is False.
+ * @see https://core.telegram.org/bots/api#message
+ */
+export interface SetGameScore {
+  /**
+   * User identifier
+   */
+  user_id: number;
+
+  /**
+   * New score, must be non-negative
+   */
+  score: number;
+
+  /**
+   * Pass True, if the high score is allowed to decrease. This can be useful 
+   * when fixing mistakes or banning cheaters
+   */
+  force?: boolean;
+
+  /**
+   * Pass True, if the game message should not be automatically edited to 
+   * include the current scoreboard
+   */
+  disable_edit_message?: boolean;
+
+  /**
+   * Required if inline_message_id is not specified. Unique identifier for 
+   * the target chat
+   */
+  chat_id?: number;
+
+  /**
+   * Required if inline_message_id is not specified. Identifier of the sent message
+   */
+  message_id?: number;
+
+  /**
+   * Required if chat_id and message_id are not specified. Identifier of the 
+   * inline message
+   */
+  inline_message_id?: string;
+}
+
+/**
+ * Use this method to get data for high score tables. Will return the score 
+ * of the specified user and several of their neighbors in a game. On 
+ * success, returns an Array of GameHighScore objects.
+ * @see https://core.telegram.org/bots/api#gamehighscore
+ */
+export interface GetGameHighScores {
+  /**
+   * Target user id
+   */
+  user_id: number;
+
+  /**
+   * Required if inline_message_id is not specified. Unique identifier for 
+   * the target chat
+   */
+  chat_id?: number;
+
+  /**
+   * Required if inline_message_id is not specified. Identifier of the sent message
+   */
+  message_id?: number;
+
+  /**
+   * Required if chat_id and message_id are not specified. Identifier of the 
+   * inline message
+   */
+  inline_message_id?: string;
 }
 
 /**

--- a/javascript/index.js.flow
+++ b/javascript/index.js.flow
@@ -18,27 +18,128 @@ declare module "telegram-typings" {
    */
   declare type PassportData = {
     /**
-    
+     * Array with information about documents and other Telegram Passport 
+     * elements that was shared with the bot
      */
     data: EncryptedPassportElement[],
 
     /**
-    
+     * Encrypted credentials required to decrypt the data
      */
     credentials: EncryptedCredentials,
   };
 
   /**
-  
+   * Contains information about documents or other Telegram Passport elements 
+   * shared with the bot by the user.
    */
-  declare type EncryptedPassportElement = {};
+  declare type EncryptedPassportElement = {
+    /**
+     * Element type. One of “personal_details”, “passport”, “driver_license”, 
+     * “identity_card”, “internal_passport”, “address”, “utility_bill”, 
+     * “bank_statement”, “rental_agreement”, “passport_registration”, 
+     * “temporary_registration”, “phone_number”, “email”.
+     */
+    type: string,
+
+    /**
+     * Base64-encoded encrypted Telegram Passport element data provided by the 
+     * user, available for “personal_details”, “passport”, “driver_license”, 
+     * “identity_card”, “internal_passport” and “address” types. Can be 
+     * decrypted and verified using the accompanying EncryptedCredentials.
+     * @see https://core.telegram.org/bots/api#encryptedcredentials
+     */
+    data?: string,
+
+    /**
+     * User's verified phone number, available only for “phone_number” type
+     */
+    phone_number?: string,
+
+    /**
+     * User's verified email address, available only for “email” type
+     */
+    email?: string,
+
+    /**
+     * Array of encrypted files with documents provided by the user, available 
+     * for “utility_bill”, “bank_statement”, “rental_agreement”, 
+     * “passport_registration” and “temporary_registration” types. Files can be 
+     * decrypted and verified using the accompanying EncryptedCredentials.
+     * @see https://core.telegram.org/bots/api#encryptedcredentials
+     */
+    files?: PassportFile[],
+
+    /**
+     * Encrypted file with the front side of the document, provided by the 
+     * user. Available for “passport”, “driver_license”, “identity_card” and 
+     * “internal_passport”. The file can be decrypted and verified using the 
+     * accompanying EncryptedCredentials.
+     * @see https://core.telegram.org/bots/api#encryptedcredentials
+     */
+    front_side?: PassportFile,
+
+    /**
+     * Encrypted file with the reverse side of the document, provided by the 
+     * user. Available for “driver_license” and “identity_card”. The file can 
+     * be decrypted and verified using the accompanying EncryptedCredentials.
+     * @see https://core.telegram.org/bots/api#encryptedcredentials
+     */
+    reverse_side?: PassportFile,
+
+    /**
+     * Encrypted file with the selfie of the user holding a document, provided 
+     * by the user; available for “passport”, “driver_license”, “identity_card” 
+     * and “internal_passport”. The file can be decrypted and verified using 
+     * the accompanying EncryptedCredentials.
+     * @see https://core.telegram.org/bots/api#encryptedcredentials
+     */
+    selfie?: PassportFile,
+
+    /**
+     * Array of encrypted files with translated versions of documents provided 
+     * by the user. Available if requested for “passport”, “driver_license”, 
+     * “identity_card”, “internal_passport”, “utility_bill”, “bank_statement”, 
+     * “rental_agreement”, “passport_registration” and “temporary_registration” 
+     * types. Files can be decrypted and verified using the accompanying EncryptedCredentials.
+     * @see https://core.telegram.org/bots/api#encryptedcredentials
+     */
+    translation?: PassportFile[],
+
+    /**
+     * Base64-encoded element hash for using in PassportElementErrorUnspecified
+     * @see https://core.telegram.org/bots/api#passportelementerrorunspecified
+     */
+    hash: string,
+  };
 
   /**
    * Contains data required for decrypting and authenticating 
    * EncryptedPassportElement. See the Telegram Passport Documentation for a 
    * complete description of the data decryption and authentication processes.
+   * @see https://core.telegram.org/bots/api#encryptedpassportelement
+   * @see https://core.telegram.org/passport#receiving-information
    */
-  declare type EncryptedCredentials = {};
+  declare type EncryptedCredentials = {
+    /**
+     * Base64-encoded encrypted JSON-serialized data with unique user's 
+     * payload, data hashes and secrets required for EncryptedPassportElement 
+     * decryption and authentication
+     * @see https://core.telegram.org/bots/api#encryptedpassportelement
+     */
+    data: string,
+
+    /**
+     * Base64-encoded data hash for data authentication
+     */
+    hash: string,
+
+    /**
+     * Base64-encoded secret, encrypted with the bot's public RSA key, required 
+     * for data decryption
+     */
+    secret: string,
+  };
 
   /**
    * This object represents the content of a message to be sent as a result 
@@ -57,15 +158,21 @@ declare module "telegram-typings" {
   declare type InlineQueryResult = InlineQueryResultCachedAudio | InlineQueryResultCachedDocument | InlineQueryResultCachedGif | InlineQueryResultCachedMpeg4Gif | InlineQueryResultCachedPhoto | InlineQueryResultCachedSticker | InlineQueryResultCachedVideo | InlineQueryResultCachedVoice | InlineQueryResultArticle | InlineQueryResultAudio | InlineQueryResultContact | InlineQueryResultGame | InlineQueryResultDocument | InlineQueryResultGif | InlineQueryResultLocation | InlineQueryResultMpeg4Gif | InlineQueryResultPhoto | InlineQueryResultVenue | InlineQueryResultVideo | InlineQueryResultVoice;
 
   /**
+   * This object represents an error in the Telegram Passport element which 
+   * was submitted that should be resolved by the user
+   */
+  declare type PassportElementError = PassportElementErrorDataField | PassportElementErrorFrontSide | PassportElementErrorReverseSide | PassportElementErrorSelfie | PassportElementErrorFile | PassportElementErrorFiles | PassportElementErrorTranslationFile | PassportElementErrorTranslationFiles | PassportElementErrorUnspecified;
+
+  /**
    * This object represents an incoming update.At most one of the optional 
    * parameters can be present in any given update.
    * @see https://core.telegram.org/bots/api#available-types
    */
   declare type Update = {
     /**
-     * The update‘s unique identifier. Update identifiers start from a certain 
+     * The update's unique identifier. Update identifiers start from a certain 
      * positive number and increase sequentially. This ID becomes especially 
-     * handy if you’re using Webhooks, since it allows you to ignore repeated 
+     * handy if you're using Webhooks, since it allows you to ignore repeated 
      * updates or to restore the correct update sequence, should they get out 
      * of order. If there are no new updates for at least a week, then 
      * identifier of the next update will be chosen randomly instead of sequentially.
@@ -122,6 +229,106 @@ declare module "telegram-typings" {
      * New incoming pre-checkout query. Contains full information about checkout
      */
     pre_checkout_query?: PreCheckoutQuery,
+
+    /**
+     * New poll state. Bots receive only updates about stopped polls and polls, 
+     * which are sent by the bot
+     */
+    poll?: Poll,
+
+    /**
+     * A user changed their answer in a non-anonymous poll. Bots receive new 
+     * votes only in polls that were sent by the bot itself.
+     */
+    poll_answer?: PollAnswer,
+  };
+
+  /**
+   * Use this method to receive incoming updates using long polling (wiki). 
+   * An Array of Update objects is returned.
+   * @see https://en.wikipedia.org/wiki/Push_technology#Long_polling
+   * @see https://core.telegram.org/bots/api#update
+   */
+  declare type GetUpdatesPayload = {
+    /**
+     * Identifier of the first update to be returned. Must be greater by one 
+     * than the highest among the identifiers of previously received updates. 
+     * By default, updates starting with the earliest unconfirmed update are 
+     * returned. An update is considered confirmed as soon as getUpdates is 
+     * called with an offset higher than its update_id. The negative offset can 
+     * be specified to retrieve updates starting from -offset update from the 
+     * end of the updates queue. All previous updates will forgotten.
+     * @see https://core.telegram.org/bots/api#getupdates
+     */
+    offset?: number,
+
+    /**
+     * Limits the number of updates to be retrieved. Values between 1-100 are 
+     * accepted. Defaults to 100.
+     */
+    limit?: number,
+
+    /**
+     * Timeout in seconds for long polling. Defaults to 0, i.e. usual short 
+     * polling. Should be positive, short polling should be used for testing 
+     * purposes only.
+     */
+    timeout?: number,
+
+    /**
+     * A JSON-serialized list of the update types you want your bot to receive. 
+     * For example, specify [“message”, “edited_channel_post”, 
+     * “callback_query”] to only receive updates of these types. See Update for 
+     * a complete list of available update types. Specify an empty list to 
+     * receive all updates regardless of type (default). If not specified, the 
+     * previous setting will be used.Please note that this parameter doesn't 
+     * affect updates created before the call to the getUpdates, so unwanted 
+     * updates may be received for a short period of time.
+     * @see https://core.telegram.org/bots/api#update
+     */
+    allowed_updates?: string[],
+  };
+
+  /**
+   * Use this method to specify a url and receive incoming updates via an 
+   * outgoing webhook. Whenever there is an update for the bot, we will send 
+   * an HTTPS POST request to the specified url, containing a JSON-serialized 
+   * Update. In case of an unsuccessful request, we will give up after a 
+   * reasonable amount of attempts. Returns True on success.
+   * @see https://core.telegram.org/bots/api#update
+   */
+  declare type SetWebhookPayload = {
+    /**
+     * HTTPS url to send updates to. Use an empty string to remove webhook integration
+     */
+    url: string,
+
+    /**
+     * Upload your public key certificate so that the root certificate in use 
+     * can be checked. See our self-signed guide for details.
+     * @see https://core.telegram.org/bots/api/bots/self-signed
+     */
+    certificate?: InputFile,
+
+    /**
+     * Maximum allowed number of simultaneous HTTPS connections to the webhook 
+     * for update delivery, 1-100. Defaults to 40. Use lower values to limit 
+     * the load on your bot's server, and higher values to increase your bot's throughput.
+     */
+    max_connections?: number,
+
+    /**
+     * A JSON-serialized list of the update types you want your bot to receive. 
+     * For example, specify [“message”, “edited_channel_post”, 
+     * “callback_query”] to only receive updates of these types. See Update for 
+     * a complete list of available update types. Specify an empty list to 
+     * receive all updates regardless of type (default). If not specified, the 
+     * previous setting will be used.Please note that this parameter doesn't 
+     * affect updates created before the call to the setWebhook, so unwanted 
+     * updates may be received for a short period of time.
+     * @see https://core.telegram.org/bots/api#update
+     */
+    allowed_updates?: string[],
   };
 
   /**
@@ -182,17 +389,17 @@ declare module "telegram-typings" {
     is_bot: boolean,
 
     /**
-     * User‘s or bot’s first name
+     * User's or bot's first name
      */
     first_name: string,
 
     /**
-     * User‘s or bot’s last name
+     * User's or bot's last name
      */
     last_name?: string,
 
     /**
-     * User‘s or bot’s username
+     * User's or bot's username
      */
     username?: string,
 
@@ -201,6 +408,25 @@ declare module "telegram-typings" {
      * @see https://en.wikipedia.org/wiki/IETF_language_tag
      */
     language_code?: string,
+
+    /**
+     * True, if the bot can be invited to groups. Returned only in getMe.
+     * @see https://core.telegram.org/bots/api#getme
+     */
+    can_join_groups?: boolean,
+
+    /**
+     * True, if privacy mode is disabled for the bot. Returned only in getMe.
+     * @see https://core.telegram.org/bots#privacy-mode
+     * @see https://core.telegram.org/bots/api#getme
+     */
+    can_read_all_group_messages?: boolean,
+
+    /**
+     * True, if the bot supports inline queries. Returned only in getMe.
+     * @see https://core.telegram.org/bots/api#getme
+     */
+    supports_inline_queries?: boolean,
   };
 
   /**
@@ -241,33 +467,46 @@ declare module "telegram-typings" {
     last_name?: string,
 
     /**
-     * True if a group has ‘All Members Are Admins’ enabled.
-     */
-    all_members_are_administrators?: boolean,
-
-    /**
      * Chat photo. Returned only in getChat.
      * @see https://core.telegram.org/bots/api#getchat
      */
     photo?: ChatPhoto,
 
     /**
-     * Description, for supergroups and channel chats. Returned only in getChat.
+     * Description, for groups, supergroups and channel chats. Returned only in getChat.
      * @see https://core.telegram.org/bots/api#getchat
      */
     description?: string,
 
     /**
-     * Chat invite link, for supergroups and channel chats. Returned only in getChat.
+     * Chat invite link, for groups, supergroups and channel chats. Each 
+     * administrator in a chat generates their own invite links, so the bot 
+     * must first generate the link using exportChatInviteLink. Returned only 
+     * in getChat.
+     * @see https://core.telegram.org/bots/api#exportchatinvitelink
      * @see https://core.telegram.org/bots/api#getchat
      */
     invite_link?: string,
 
     /**
-     * Pinned message, for supergroups and channel chats. Returned only in getChat.
+     * Pinned message, for groups, supergroups and channels. Returned only in getChat.
      * @see https://core.telegram.org/bots/api#getchat
      */
     pinned_message?: Message,
+
+    /**
+     * Default chat member permissions, for groups and supergroups. Returned 
+     * only in getChat.
+     * @see https://core.telegram.org/bots/api#getchat
+     */
+    permissions?: ChatPermissions,
+
+    /**
+     * For supergroups, the minimum allowed delay between consecutive messages 
+     * sent by each unpriviledged user. Returned only in getChat.
+     * @see https://core.telegram.org/bots/api#getchat
+     */
+    slow_mode_delay?: number,
 
     /**
      * For supergroups, name of group sticker set. Returned only in getChat.
@@ -328,6 +567,12 @@ declare module "telegram-typings" {
     forward_signature?: string,
 
     /**
+     * Sender's name for messages forwarded from users who disallow adding a 
+     * link to their account in forwarded messages
+     */
+    forward_sender_name?: string,
+
+    /**
      * For forwarded messages, date the original message was sent in Unix time
      */
     forward_date?: number,
@@ -338,6 +583,11 @@ declare module "telegram-typings" {
      * is a reply.
      */
     reply_to_message?: Message,
+
+    /**
+     * Bot through which the message was sent
+     */
+    via_bot?: User,
 
     /**
      * Date the message was last edited in Unix time
@@ -355,7 +605,7 @@ declare module "telegram-typings" {
     author_signature?: string,
 
     /**
-     * For text messages, the actual UTF-8 text of the message, 0-4096 characters.
+     * For text messages, the actual UTF-8 text of the message, 0-4096 characters
      */
     text?: string,
 
@@ -366,10 +616,10 @@ declare module "telegram-typings" {
     entities?: MessageEntity[],
 
     /**
-     * For messages with a caption, special entities like usernames, URLs, bot 
-     * commands, etc. that appear in the caption
+     * Message is an animation, information about the animation. For backward 
+     * compatibility, when this field is set, the document field will also be set
      */
-    caption_entities?: MessageEntity[],
+    animation?: Animation,
 
     /**
      * Message is an audio file, information about the file
@@ -380,18 +630,6 @@ declare module "telegram-typings" {
      * Message is a general file, information about the file
      */
     document?: Document,
-
-    /**
-     * Message is an animation, information about the animation. For backward 
-     * compatibility, when this field is set, the document field will also be set
-     */
-    animation?: Animation,
-
-    /**
-     * Message is a game, information about the game. More about games »
-     * @see https://core.telegram.org/bots/api#games
-     */
-    game?: Game,
 
     /**
      * Message is a photo, available sizes of the photo
@@ -409,20 +647,27 @@ declare module "telegram-typings" {
     video?: Video,
 
     /**
-     * Message is a voice message, information about the file
-     */
-    voice?: Voice,
-
-    /**
      * Message is a video note, information about the video message
      * @see https://telegram.org/blog/video-messages-and-telescope
      */
     video_note?: VideoNote,
 
     /**
-     * Caption for the audio, document, photo, video or voice, 0-200 characters
+     * Message is a voice message, information about the file
+     */
+    voice?: Voice,
+
+    /**
+     * Caption for the animation, audio, document, photo, video or voice, 
+     * 0-1024 characters
      */
     caption?: string,
+
+    /**
+     * For messages with a caption, special entities like usernames, URLs, bot 
+     * commands, etc. that appear in the caption
+     */
+    caption_entities?: MessageEntity[],
 
     /**
      * Message is a shared contact, information about the contact
@@ -430,14 +675,31 @@ declare module "telegram-typings" {
     contact?: Contact,
 
     /**
+     * Message is a dice with random value from 1 to 6
+     */
+    dice?: Dice,
+
+    /**
+     * Message is a game, information about the game. More about games »
+     * @see https://core.telegram.org/bots/api#games
+     */
+    game?: Game,
+
+    /**
+     * Message is a native poll, information about the poll
+     */
+    poll?: Poll,
+
+    /**
+     * Message is a venue, information about the venue. For backward 
+     * compatibility, when this field is set, the location field will also be set
+     */
+    venue?: Venue,
+
+    /**
      * Message is a shared location, information about the location
      */
     location?: Location,
-
-    /**
-     * Message is a venue, information about the venue
-     */
-    venue?: Venue,
 
     /**
      * New members that were added to the group or supergroup and information 
@@ -472,8 +734,8 @@ declare module "telegram-typings" {
     group_chat_created?: true,
 
     /**
-     * Service message: the supergroup has been created. This field can‘t be 
-     * received in a message coming through updates, because bot can’t be a 
+     * Service message: the supergroup has been created. This field can't be 
+     * received in a message coming through updates, because bot can't be a 
      * member of a supergroup when it is created. It can only be found in 
      * reply_to_message if someone replies to a very first message in a 
      * directly created supergroup.
@@ -481,8 +743,8 @@ declare module "telegram-typings" {
     supergroup_chat_created?: true,
 
     /**
-     * Service message: the channel has been created. This field can‘t be 
-     * received in a message coming through updates, because bot can’t be a 
+     * Service message: the channel has been created. This field can't be 
+     * received in a message coming through updates, because bot can't be a 
      * member of a channel when it is created. It can only be found in 
      * reply_to_message if someone replies to a very first message in a channel.
      */
@@ -537,6 +799,12 @@ declare module "telegram-typings" {
      * Telegram Passport data
      */
     passport_data?: PassportData,
+
+    /**
+     * Inline keyboard attached to the message. login_url buttons are 
+     * represented as ordinary url buttons.
+     */
+    reply_markup?: InlineKeyboardMarkup,
   };
 
   /**
@@ -545,10 +813,13 @@ declare module "telegram-typings" {
    */
   declare type MessageEntity = {
     /**
-     * Type of the entity. Can be mention (@username), hashtag, cashtag, 
-     * bot_command, url, email, phone_number, bold (bold text), italic (italic 
-     * text), code (monowidth string), pre (monowidth block), text_link (for 
-     * clickable text URLs), text_mention (for users without usernames)
+     * Type of the entity. Can be “mention” (@username), “hashtag” (#hashtag), 
+     * “cashtag” ($USD), “bot_command” (/start@jobs_bot), “url” 
+     * (https://telegram.org), “email” (do-not-reply@telegram.org), 
+     * “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic 
+     * text), “underline” (underlined text), “strikethrough” (strikethrough 
+     * text), “code” (monowidth string), “pre” (monowidth block), “text_link” 
+     * (for clickable text URLs), “text_mention” (for users without usernames)
      * @see https://telegram.org/blog/edit#new-mentions
      */
     type: string,
@@ -572,6 +843,11 @@ declare module "telegram-typings" {
      * For “text_mention” only, the mentioned user
      */
     user?: User,
+
+    /**
+     * For “pre” only, the programming language of the entity text
+     */
+    language?: string,
   };
 
   /**
@@ -581,9 +857,15 @@ declare module "telegram-typings" {
    */
   declare type PhotoSize = {
     /**
-     * Unique identifier for this file
+     * Identifier for this file, which can be used to download or reuse the file
      */
     file_id: string,
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over 
+     * time and for different bots. Can't be used to download or reuse the file.
+     */
+    file_unique_id: string,
 
     /**
      * Photo width
@@ -602,14 +884,72 @@ declare module "telegram-typings" {
   };
 
   /**
+   * This object represents an animation file (GIF or H.264/MPEG-4 AVC video 
+   * without sound).
+   */
+  declare type Animation = {
+    /**
+     * Identifier for this file, which can be used to download or reuse the file
+     */
+    file_id: string,
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over 
+     * time and for different bots. Can't be used to download or reuse the file.
+     */
+    file_unique_id: string,
+
+    /**
+     * Video width as defined by sender
+     */
+    width: number,
+
+    /**
+     * Video height as defined by sender
+     */
+    height: number,
+
+    /**
+     * Duration of the video in seconds as defined by sender
+     */
+    duration: number,
+
+    /**
+     * Animation thumbnail as defined by sender
+     */
+    thumb?: PhotoSize,
+
+    /**
+     * Original animation filename as defined by sender
+     */
+    file_name?: string,
+
+    /**
+     * MIME type of the file as defined by sender
+     */
+    mime_type?: string,
+
+    /**
+     * File size
+     */
+    file_size?: number,
+  };
+
+  /**
    * This object represents an audio file to be treated as music by the 
    * Telegram clients.
    */
   declare type Audio = {
     /**
-     * Unique identifier for this file
+     * Identifier for this file, which can be used to download or reuse the file
      */
     file_id: string,
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over 
+     * time and for different bots. Can't be used to download or reuse the file.
+     */
+    file_unique_id: string,
 
     /**
      * Duration of the audio in seconds as defined by sender
@@ -651,9 +991,15 @@ declare module "telegram-typings" {
    */
   declare type Document = {
     /**
-     * Unique file identifier
+     * Identifier for this file, which can be used to download or reuse the file
      */
     file_id: string,
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over 
+     * time and for different bots. Can't be used to download or reuse the file.
+     */
+    file_unique_id: string,
 
     /**
      * Document thumbnail as defined by sender
@@ -681,9 +1027,15 @@ declare module "telegram-typings" {
    */
   declare type Video = {
     /**
-     * Unique identifier for this file
+     * Identifier for this file, which can be used to download or reuse the file
      */
     file_id: string,
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over 
+     * time and for different bots. Can't be used to download or reuse the file.
+     */
+    file_unique_id: string,
 
     /**
      * Video width as defined by sender
@@ -717,88 +1069,23 @@ declare module "telegram-typings" {
   };
 
   /**
-   * This object represents an animation file (GIF or H.264/MPEG-4 AVC video 
-   * without sound).
-   */
-  declare type Animation = {
-    /**
-     * Unique file identifier
-     */
-    file_id: string,
-
-    /**
-     * Video width as defined by sender
-     */
-    width: number,
-
-    /**
-     * Video height as defined by sender
-     */
-    height: number,
-
-    /**
-     * Duration of the video in seconds as defined by sender
-     */
-    duration: number,
-
-    /**
-     * Animation thumbnail as defined by sender
-     */
-    thumb?: PhotoSize,
-
-    /**
-     * Original animation filename as defined by sender
-     */
-    file_name?: string,
-
-    /**
-     * MIME type of the file as defined by sender
-     */
-    mime_type?: string,
-
-    /**
-     * File size
-     */
-    file_size?: number,
-  };
-
-  /**
-   * This object represents a voice note.
-   */
-  declare type Voice = {
-    /**
-     * Unique identifier for this file
-     */
-    file_id: string,
-
-    /**
-     * Duration of the audio in seconds as defined by sender
-     */
-    duration: number,
-
-    /**
-     * MIME type of the file as defined by sender
-     */
-    mime_type?: string,
-
-    /**
-     * File size
-     */
-    file_size?: number,
-  };
-
-  /**
    * This object represents a video message (available in Telegram apps as of v.4.0).
    * @see https://telegram.org/blog/video-messages-and-telescope
    */
   declare type VideoNote = {
     /**
-     * Unique identifier for this file
+     * Identifier for this file, which can be used to download or reuse the file
      */
     file_id: string,
 
     /**
-     * Video width and height as defined by sender
+     * Unique identifier for this file, which is supposed to be the same over 
+     * time and for different bots. Can't be used to download or reuse the file.
+     */
+    file_unique_id: string,
+
+    /**
+     * Video width and height (diameter of the video message) as defined by sender
      */
     length: number,
 
@@ -811,6 +1098,37 @@ declare module "telegram-typings" {
      * Video thumbnail
      */
     thumb?: PhotoSize,
+
+    /**
+     * File size
+     */
+    file_size?: number,
+  };
+
+  /**
+   * This object represents a voice note.
+   */
+  declare type Voice = {
+    /**
+     * Identifier for this file, which can be used to download or reuse the file
+     */
+    file_id: string,
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over 
+     * time and for different bots. Can't be used to download or reuse the file.
+     */
+    file_unique_id: string,
+
+    /**
+     * Duration of the audio in seconds as defined by sender
+     */
+    duration: number,
+
+    /**
+     * MIME type of the file as defined by sender
+     */
+    mime_type?: string,
 
     /**
      * File size
@@ -847,6 +1165,131 @@ declare module "telegram-typings" {
      * @see https://en.wikipedia.org/wiki/VCard
      */
     vcard?: string,
+  };
+
+  /**
+   * This object represents an animated emoji that displays a random value.
+   */
+  declare type Dice = {
+    /**
+     * Emoji on which the dice throw animation is based
+     */
+    emoji: string,
+
+    /**
+     * Value of the dice, 1-6 for “” and “” base emoji, 1-5 for “” base emoji
+     */
+    value: number,
+  };
+
+  /**
+   * This object contains information about one answer option in a poll.
+   */
+  declare type PollOption = {
+    /**
+     * Option text, 1-100 characters
+     */
+    text: string,
+
+    /**
+     * Number of users that voted for this option
+     */
+    voter_count: number,
+  };
+
+  /**
+   * This object represents an answer of a user in a non-anonymous poll.
+   */
+  declare type PollAnswer = {
+    /**
+     * Unique poll identifier
+     */
+    poll_id: string,
+
+    /**
+     * The user, who changed the answer to the poll
+     */
+    user: User,
+
+    /**
+     * 0-based identifiers of answer options, chosen by the user. May be empty 
+     * if the user retracted their vote.
+     */
+    option_ids: number[],
+  };
+
+  /**
+   * This object contains information about a poll.
+   */
+  declare type Poll = {
+    /**
+     * Unique poll identifier
+     */
+    id: string,
+
+    /**
+     * Poll question, 1-255 characters
+     */
+    question: string,
+
+    /**
+     * List of poll options
+     */
+    options: PollOption[],
+
+    /**
+     * Total number of users that voted in the poll
+     */
+    total_voter_count: number,
+
+    /**
+     * True, if the poll is closed
+     */
+    is_closed: boolean,
+
+    /**
+     * True, if the poll is anonymous
+     */
+    is_anonymous: boolean,
+
+    /**
+     * Poll type, currently can be “regular” or “quiz”
+     */
+    type: string,
+
+    /**
+     * True, if the poll allows multiple answers
+     */
+    allows_multiple_answers: boolean,
+
+    /**
+     * 0-based identifier of the correct answer option. Available only for 
+     * polls in the quiz mode, which are closed, or was sent (not forwarded) by 
+     * the bot or to the private chat with the bot.
+     */
+    correct_option_id?: number,
+
+    /**
+     * Text that is shown when a user chooses an incorrect answer or taps on 
+     * the lamp icon in a quiz-style poll, 0-200 characters
+     */
+    explanation?: string,
+
+    /**
+     * Special entities like usernames, URLs, bot commands, etc. that appear in 
+     * the explanation
+     */
+    explanation_entities?: MessageEntity[],
+
+    /**
+     * Amount of time in seconds the poll will be active after creation
+     */
+    open_period?: number,
+
+    /**
+     * Point in time (Unix timestamp) when the poll will be automatically closed
+     */
+    close_date?: number,
   };
 
   /**
@@ -920,9 +1363,15 @@ declare module "telegram-typings" {
    */
   declare type File = {
     /**
-     * Unique identifier for this file
+     * Identifier for this file, which can be used to download or reuse the file
      */
     file_id: string,
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over 
+     * time and for different bots. Can't be used to download or reuse the file.
+     */
+    file_unique_id: string,
 
     /**
      * File size, if known
@@ -969,8 +1418,8 @@ declare module "telegram-typings" {
      * only. Targets: 1) users that are @mentioned in the text of the Message 
      * object; 2) if the bot's message is a reply (has reply_to_message_id), 
      * sender of the original message.Example: A user requests to change the 
-     * bot‘s language, bot replies to the request with a keyboard to select the 
-     * new language. Other users in the group don’t see the keyboard.
+     * bot's language, bot replies to the request with a keyboard to select the 
+     * new language. Other users in the group don't see the keyboard.
      * @see https://core.telegram.org/bots/api#message
      */
     selective?: boolean,
@@ -979,7 +1428,8 @@ declare module "telegram-typings" {
   /**
    * This object represents one button of the reply keyboard. For simple text 
    * buttons String can be used instead of this object to specify text of the 
-   * button. Optional fields are mutually exclusive.
+   * button. Optional fields request_contact, request_location, and 
+   * request_poll are mutually exclusive.
    */
   declare type KeyboardButton = {
     /**
@@ -999,6 +1449,25 @@ declare module "telegram-typings" {
      * pressed. Available in private chats only
      */
     request_location?: boolean,
+
+    /**
+     * If specified, the user will be asked to create a poll and send it to the 
+     * bot when the button is pressed. Available in private chats only
+     */
+    request_poll?: KeyboardButtonPollType,
+  };
+
+  /**
+   * This object represents type of a poll, which is allowed to be created 
+   * and sent when the corresponding button is pressed.
+   */
+  declare type KeyboardButtonPollType = {
+    /**
+     * If quiz is passed, the user will be allowed to create only polls in the 
+     * quiz mode. If regular is passed, only regular polls will be allowed. 
+     * Otherwise, the user will be allowed to create a poll of any type.
+     */
+    type?: string
   };
 
   /**
@@ -1061,6 +1530,13 @@ declare module "telegram-typings" {
     url?: string,
 
     /**
+     * An HTTP URL used to automatically authorize the user. Can be used as a 
+     * replacement for the Telegram Login Widget.
+     * @see https://core.telegram.org/widgets/login
+     */
+    login_url?: LoginUrl,
+
+    /**
      * Data to be sent in a callback query to the bot when button is pressed, 
      * 1-64 bytes
      * @see https://core.telegram.org/bots/api#callbackquery
@@ -1069,9 +1545,9 @@ declare module "telegram-typings" {
 
     /**
      * If set, pressing the button will prompt the user to select one of their 
-     * chats, open that chat and insert the bot‘s username and the specified 
+     * chats, open that chat and insert the bot's username and the specified 
      * inline query in the input field. Can be empty, in which case just the 
-     * bot’s username will be inserted.Note: This offers an easy way for users 
+     * bot's username will be inserted.Note: This offers an easy way for users 
      * to start using your bot in inline mode when they are currently in a 
      * private chat with it. Especially useful when combined with switch_pm… 
      * actions – in this case the user will be automatically returned to the 
@@ -1082,9 +1558,9 @@ declare module "telegram-typings" {
     switch_inline_query?: string,
 
     /**
-     * If set, pressing the button will insert the bot‘s username and the 
+     * If set, pressing the button will insert the bot's username and the 
      * specified inline query in the current chat's input field. Can be empty, 
-     * in which case only the bot’s username will be inserted.This offers a 
+     * in which case only the bot's username will be inserted.This offers a 
      * quick way for the user to open your bot in inline mode in the same chat 
      * – good for selecting something from multiple options.
      */
@@ -1103,6 +1579,48 @@ declare module "telegram-typings" {
      * @see https://core.telegram.org/bots/api#payments
      */
     pay?: boolean,
+  };
+
+  /**
+   * This object represents a parameter of the inline keyboard button used to 
+   * automatically authorize a user. Serves as a great replacement for the 
+   * Telegram Login Widget when the user is coming from Telegram. All the 
+   * user needs to do is tap/click a button and confirm that they want to log in:
+   * @see https://core.telegram.org/widgets/login
+   */
+  declare type LoginUrl = {
+    /**
+     * An HTTP URL to be opened with user authorization data added to the query 
+     * string when the button is pressed. If the user refuses to provide 
+     * authorization data, the original URL without information about the user 
+     * will be opened. The data added is the same as described in Receiving 
+     * authorization data.NOTE: You must always check the hash of the received 
+     * data to verify the authentication and the integrity of the data as 
+     * described in Checking authorization.
+     * @see https://core.telegram.org/widgets/login#receiving-authorization-data
+     * @see https://core.telegram.org/widgets/login#checking-authorization
+     */
+    url: string,
+
+    /**
+     * New text of the button in forwarded messages.
+     */
+    forward_text?: string,
+
+    /**
+     * Username of a bot, which will be used for user authorization. See 
+     * Setting up a bot for more details. If not specified, the current bot's 
+     * username will be assumed. The url's domain must be the same as the 
+     * domain linked with the bot. See Linking your domain to the bot for more details.
+     * @see https://core.telegram.org/widgets/login#setting-up-a-bot
+     * @see https://core.telegram.org/widgets/login#linking-your-domain-to-the-bot
+     */
+    bot_username?: string,
+
+    /**
+     * Pass True to request the permission for your bot to send messages to the user.
+     */
+    request_write_access?: boolean,
   };
 
   /**
@@ -1162,8 +1680,8 @@ declare module "telegram-typings" {
 
   /**
    * Upon receiving a message with this object, Telegram clients will display 
-   * a reply interface to the user (act as if the user has selected the bot‘s 
-   * message and tapped ’Reply'). This can be extremely useful if you want to 
+   * a reply interface to the user (act as if the user has selected the bot's 
+   * message and tapped 'Reply'). This can be extremely useful if you want to 
    * create user-friendly step-by-step interfaces without having to sacrifice 
    * privacy mode.
    * @see https://core.telegram.org/bots/api/bots#privacy-mode
@@ -1171,7 +1689,7 @@ declare module "telegram-typings" {
   declare type ForceReply = {
     /**
      * Shows reply interface to the user, as if they manually selected the 
-     * bot‘s message and tapped ’Reply'
+     * bot's message and tapped 'Reply'
      */
     force_reply: true,
 
@@ -1190,16 +1708,30 @@ declare module "telegram-typings" {
    */
   declare type ChatPhoto = {
     /**
-     * Unique file identifier of small (160x160) chat photo. This file_id can 
-     * be used only for photo download.
+     * File identifier of small (160x160) chat photo. This file_id can be used 
+     * only for photo download and only for as long as the photo is not changed.
      */
     small_file_id: string,
 
     /**
-     * Unique file identifier of big (640x640) chat photo. This file_id can be 
-     * used only for photo download.
+     * Unique file identifier of small (160x160) chat photo, which is supposed 
+     * to be the same over time and for different bots. Can't be used to 
+     * download or reuse the file.
+     */
+    small_file_unique_id: string,
+
+    /**
+     * File identifier of big (640x640) chat photo. This file_id can be used 
+     * only for photo download and only for as long as the photo is not changed.
      */
     big_file_id: string,
+
+    /**
+     * Unique file identifier of big (640x640) chat photo, which is supposed to 
+     * be the same over time and for different bots. Can't be used to download 
+     * or reuse the file.
+     */
+    big_file_unique_id: string,
   };
 
   /**
@@ -1218,8 +1750,13 @@ declare module "telegram-typings" {
     status: string,
 
     /**
+     * Owner and administrators only. Custom title for this user
+     */
+    custom_title?: string,
+
+    /**
      * Restricted and kicked only. Date when restrictions will be lifted for 
-     * this user, unix time
+     * this user; unix time
      */
     until_date?: number,
 
@@ -1230,20 +1767,14 @@ declare module "telegram-typings" {
     can_be_edited?: boolean,
 
     /**
-     * Administrators only. True, if the administrator can change the chat 
-     * title, photo and other settings
-     */
-    can_change_info?: boolean,
-
-    /**
-     * Administrators only. True, if the administrator can post in the channel, 
+     * Administrators only. True, if the administrator can post in the channel; 
      * channels only
      */
     can_post_messages?: boolean,
 
     /**
      * Administrators only. True, if the administrator can edit messages of 
-     * other users and can pin messages, channels only
+     * other users and can pin messages; channels only
      */
     can_edit_messages?: boolean,
 
@@ -1254,54 +1785,137 @@ declare module "telegram-typings" {
     can_delete_messages?: boolean,
 
     /**
-     * Administrators only. True, if the administrator can invite new users to 
-     * the chat
-     */
-    can_invite_users?: boolean,
-
-    /**
      * Administrators only. True, if the administrator can restrict, ban or 
      * unban chat members
      */
     can_restrict_members?: boolean,
 
     /**
-     * Administrators only. True, if the administrator can pin messages, 
-     * supergroups only
-     */
-    can_pin_messages?: boolean,
-
-    /**
      * Administrators only. True, if the administrator can add new 
-     * administrators with a subset of his own privileges or demote 
+     * administrators with a subset of their own privileges or demote 
      * administrators that he has promoted, directly or indirectly (promoted by 
      * administrators that were appointed by the user)
      */
     can_promote_members?: boolean,
 
     /**
-     * Restricted only. True, if the user can send text messages, contacts, 
-     * locations and venues
+     * Administrators and restricted only. True, if the user is allowed to 
+     * change the chat title, photo and other settings
+     */
+    can_change_info?: boolean,
+
+    /**
+     * Administrators and restricted only. True, if the user is allowed to 
+     * invite new users to the chat
+     */
+    can_invite_users?: boolean,
+
+    /**
+     * Administrators and restricted only. True, if the user is allowed to pin 
+     * messages; groups and supergroups only
+     */
+    can_pin_messages?: boolean,
+
+    /**
+     * Restricted only. True, if the user is a member of the chat at the moment 
+     * of the request
+     */
+    is_member?: boolean,
+
+    /**
+     * Restricted only. True, if the user is allowed to send text messages, 
+     * contacts, locations and venues
      */
     can_send_messages?: boolean,
 
     /**
-     * Restricted only. True, if the user can send audios, documents, photos, 
-     * videos, video notes and voice notes, implies can_send_messages
+     * Restricted only. True, if the user is allowed to send audios, documents, 
+     * photos, videos, video notes and voice notes
      */
     can_send_media_messages?: boolean,
 
     /**
-     * Restricted only. True, if the user can send animations, games, stickers 
-     * and use inline bots, implies can_send_media_messages
+     * Restricted only. True, if the user is allowed to send polls
+     */
+    can_send_polls?: boolean,
+
+    /**
+     * Restricted only. True, if the user is allowed to send animations, games, 
+     * stickers and use inline bots
      */
     can_send_other_messages?: boolean,
 
     /**
-     * Restricted only. True, if user may add web page previews to his 
-     * messages, implies can_send_media_messages
+     * Restricted only. True, if the user is allowed to add web page previews 
+     * to their messages
      */
     can_add_web_page_previews?: boolean,
+  };
+
+  /**
+   * Describes actions that a non-administrator user is allowed to take in a chat.
+   */
+  declare type ChatPermissions = {
+    /**
+     * True, if the user is allowed to send text messages, contacts, locations 
+     * and venues
+     */
+    can_send_messages?: boolean,
+
+    /**
+     * True, if the user is allowed to send audios, documents, photos, videos, 
+     * video notes and voice notes, implies can_send_messages
+     */
+    can_send_media_messages?: boolean,
+
+    /**
+     * True, if the user is allowed to send polls, implies can_send_messages
+     */
+    can_send_polls?: boolean,
+
+    /**
+     * True, if the user is allowed to send animations, games, stickers and use 
+     * inline bots, implies can_send_media_messages
+     */
+    can_send_other_messages?: boolean,
+
+    /**
+     * True, if the user is allowed to add web page previews to their messages, 
+     * implies can_send_media_messages
+     */
+    can_add_web_page_previews?: boolean,
+
+    /**
+     * True, if the user is allowed to change the chat title, photo and other 
+     * settings. Ignored in public supergroups
+     */
+    can_change_info?: boolean,
+
+    /**
+     * True, if the user is allowed to invite new users to the chat
+     */
+    can_invite_users?: boolean,
+
+    /**
+     * True, if the user is allowed to pin messages. Ignored in public supergroups
+     */
+    can_pin_messages?: boolean,
+  };
+
+  /**
+   * This object represents a bot command.
+   */
+  declare type BotCommand = {
+    /**
+     * Text of the command, 1-32 characters. Can contain only lowercase English 
+     * letters, digits and underscores.
+     */
+    command: string,
+
+    /**
+     * Description of the command, 3-256 characters.
+     */
+    description: string,
   };
 
   /**
@@ -1344,15 +1958,13 @@ declare module "telegram-typings" {
     media: string,
 
     /**
-     * Caption of the photo to be sent, 0-200 characters
+     * Caption of the photo to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the photo caption. See formatting options 
+     * for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -1378,10 +1990,11 @@ declare module "telegram-typings" {
     media: string,
 
     /**
-     * Thumbnail of the file sent. The thumbnail should be in JPEG format and 
-     * less than 200 kB in size. A thumbnail‘s width and height should not 
-     * exceed 90. Ignored if the file is not uploaded using 
-     * multipart/form-data. Thumbnails can’t be reused and can be only uploaded 
+     * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+     * the file is supported server-side. The thumbnail should be in JPEG 
+     * format and less than 200 kB in size. A thumbnail's width and height 
+     * should not exceed 320. Ignored if the file is not uploaded using 
+     * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
      * as a new file, so you can pass “attach://<file_attach_name>” if the 
      * thumbnail was uploaded using multipart/form-data under 
      * <file_attach_name>. More info on Sending Files »
@@ -1390,15 +2003,13 @@ declare module "telegram-typings" {
     thumb?: InputFile | string,
 
     /**
-     * Caption of the video to be sent, 0-200 characters
+     * Caption of the video to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the video caption. See formatting options 
+     * for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -1445,10 +2056,11 @@ declare module "telegram-typings" {
     media: string,
 
     /**
-     * Thumbnail of the file sent. The thumbnail should be in JPEG format and 
-     * less than 200 kB in size. A thumbnail‘s width and height should not 
-     * exceed 90. Ignored if the file is not uploaded using 
-     * multipart/form-data. Thumbnails can’t be reused and can be only uploaded 
+     * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+     * the file is supported server-side. The thumbnail should be in JPEG 
+     * format and less than 200 kB in size. A thumbnail's width and height 
+     * should not exceed 320. Ignored if the file is not uploaded using 
+     * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
      * as a new file, so you can pass “attach://<file_attach_name>” if the 
      * thumbnail was uploaded using multipart/form-data under 
      * <file_attach_name>. More info on Sending Files »
@@ -1457,15 +2069,13 @@ declare module "telegram-typings" {
     thumb?: InputFile | string,
 
     /**
-     * Caption of the animation to be sent, 0-200 characters
+     * Caption of the animation to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the animation caption. See formatting 
+     * options for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -1506,10 +2116,11 @@ declare module "telegram-typings" {
     media: string,
 
     /**
-     * Thumbnail of the file sent. The thumbnail should be in JPEG format and 
-     * less than 200 kB in size. A thumbnail‘s width and height should not 
-     * exceed 90. Ignored if the file is not uploaded using 
-     * multipart/form-data. Thumbnails can’t be reused and can be only uploaded 
+     * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+     * the file is supported server-side. The thumbnail should be in JPEG 
+     * format and less than 200 kB in size. A thumbnail's width and height 
+     * should not exceed 320. Ignored if the file is not uploaded using 
+     * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
      * as a new file, so you can pass “attach://<file_attach_name>” if the 
      * thumbnail was uploaded using multipart/form-data under 
      * <file_attach_name>. More info on Sending Files »
@@ -1518,15 +2129,13 @@ declare module "telegram-typings" {
     thumb?: InputFile | string,
 
     /**
-     * Caption of the audio to be sent, 0-200 characters
+     * Caption of the audio to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the audio caption. See formatting options 
+     * for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -1567,10 +2176,11 @@ declare module "telegram-typings" {
     media: string,
 
     /**
-     * Thumbnail of the file sent. The thumbnail should be in JPEG format and 
-     * less than 200 kB in size. A thumbnail‘s width and height should not 
-     * exceed 90. Ignored if the file is not uploaded using 
-     * multipart/form-data. Thumbnails can’t be reused and can be only uploaded 
+     * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+     * the file is supported server-side. The thumbnail should be in JPEG 
+     * format and less than 200 kB in size. A thumbnail's width and height 
+     * should not exceed 320. Ignored if the file is not uploaded using 
+     * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
      * as a new file, so you can pass “attach://<file_attach_name>” if the 
      * thumbnail was uploaded using multipart/form-data under 
      * <file_attach_name>. More info on Sending Files »
@@ -1579,18 +2189,1777 @@ declare module "telegram-typings" {
     thumb?: InputFile | string,
 
     /**
-     * Caption of the document to be sent, 0-200 characters
+     * Caption of the document to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the document caption. See formatting 
+     * options for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
+  };
+
+  /**
+   * Use this method to send text messages. On success, the sent Message is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendMessagePayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Text of the message to be sent, 1-4096 characters after entities parsing
+     */
+    text: string,
+
+    /**
+     * Mode for parsing entities in the message text. See formatting options 
+     * for more details.
+     * @see https://core.telegram.org/bots/api#formatting-options
+     */
+    parse_mode?: string,
+
+    /**
+     * Disables link previews for links in this message
+     */
+    disable_web_page_preview?: boolean,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method to forward messages of any kind. On success, the sent 
+   * Message is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type ForwardMessagePayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Unique identifier for the chat where the original message was sent (or 
+     * channel username in the format @channelusername)
+     */
+    from_chat_id: number | string,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * Message identifier in the chat specified in from_chat_id
+     */
+    message_id: number,
+  };
+
+  /**
+   * Use this method to send photos. On success, the sent Message is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendPhotoPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Photo to send. Pass a file_id as String to send a photo that exists on 
+     * the Telegram servers (recommended), pass an HTTP URL as a String for 
+     * Telegram to get a photo from the Internet, or upload a new photo using 
+     * multipart/form-data. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    photo: InputFile | string,
+
+    /**
+     * Photo caption (may also be used when resending photos by file_id), 
+     * 0-1024 characters after entities parsing
+     */
+    caption?: string,
+
+    /**
+     * Mode for parsing entities in the photo caption. See formatting options 
+     * for more details.
+     * @see https://core.telegram.org/bots/api#formatting-options
+     */
+    parse_mode?: string,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method to send audio files, if you want Telegram clients to 
+   * display them in the music player. Your audio must be in the .MP3 or .M4A 
+   * format. On success, the sent Message is returned. Bots can currently 
+   * send audio files of up to 50 MB in size, this limit may be changed in 
+   * the future.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendAudioPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Audio file to send. Pass a file_id as String to send an audio file that 
+     * exists on the Telegram servers (recommended), pass an HTTP URL as a 
+     * String for Telegram to get an audio file from the Internet, or upload a 
+     * new one using multipart/form-data. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    audio: InputFile | string,
+
+    /**
+     * Audio caption, 0-1024 characters after entities parsing
+     */
+    caption?: string,
+
+    /**
+     * Mode for parsing entities in the audio caption. See formatting options 
+     * for more details.
+     * @see https://core.telegram.org/bots/api#formatting-options
+     */
+    parse_mode?: string,
+
+    /**
+     * Duration of the audio in seconds
+     */
+    duration?: number,
+
+    /**
+     * Performer
+     */
+    performer?: string,
+
+    /**
+     * Track name
+     */
+    title?: string,
+
+    /**
+     * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+     * the file is supported server-side. The thumbnail should be in JPEG 
+     * format and less than 200 kB in size. A thumbnail's width and height 
+     * should not exceed 320. Ignored if the file is not uploaded using 
+     * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
+     * as a new file, so you can pass “attach://<file_attach_name>” if the 
+     * thumbnail was uploaded using multipart/form-data under 
+     * <file_attach_name>. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    thumb?: InputFile | string,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method to send general files. On success, the sent Message is 
+   * returned. Bots can currently send files of any type of up to 50 MB in 
+   * size, this limit may be changed in the future.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendDocumentPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * File to send. Pass a file_id as String to send a file that exists on the 
+     * Telegram servers (recommended), pass an HTTP URL as a String for 
+     * Telegram to get a file from the Internet, or upload a new one using 
+     * multipart/form-data. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    document: InputFile | string,
+
+    /**
+     * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+     * the file is supported server-side. The thumbnail should be in JPEG 
+     * format and less than 200 kB in size. A thumbnail's width and height 
+     * should not exceed 320. Ignored if the file is not uploaded using 
+     * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
+     * as a new file, so you can pass “attach://<file_attach_name>” if the 
+     * thumbnail was uploaded using multipart/form-data under 
+     * <file_attach_name>. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    thumb?: InputFile | string,
+
+    /**
+     * Document caption (may also be used when resending documents by file_id), 
+     * 0-1024 characters after entities parsing
+     */
+    caption?: string,
+
+    /**
+     * Mode for parsing entities in the document caption. See formatting 
+     * options for more details.
+     * @see https://core.telegram.org/bots/api#formatting-options
+     */
+    parse_mode?: string,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method to send video files, Telegram clients support mp4 videos 
+   * (other formats may be sent as Document). On success, the sent Message is 
+   * returned. Bots can currently send video files of up to 50 MB in size, 
+   * this limit may be changed in the future.
+   * @see https://core.telegram.org/bots/api#document
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendVideoPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Video to send. Pass a file_id as String to send a video that exists on 
+     * the Telegram servers (recommended), pass an HTTP URL as a String for 
+     * Telegram to get a video from the Internet, or upload a new video using 
+     * multipart/form-data. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    video: InputFile | string,
+
+    /**
+     * Duration of sent video in seconds
+     */
+    duration?: number,
+
+    /**
+     * Video width
+     */
+    width?: number,
+
+    /**
+     * Video height
+     */
+    height?: number,
+
+    /**
+     * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+     * the file is supported server-side. The thumbnail should be in JPEG 
+     * format and less than 200 kB in size. A thumbnail's width and height 
+     * should not exceed 320. Ignored if the file is not uploaded using 
+     * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
+     * as a new file, so you can pass “attach://<file_attach_name>” if the 
+     * thumbnail was uploaded using multipart/form-data under 
+     * <file_attach_name>. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    thumb?: InputFile | string,
+
+    /**
+     * Video caption (may also be used when resending videos by file_id), 
+     * 0-1024 characters after entities parsing
+     */
+    caption?: string,
+
+    /**
+     * Mode for parsing entities in the video caption. See formatting options 
+     * for more details.
+     * @see https://core.telegram.org/bots/api#formatting-options
+     */
+    parse_mode?: string,
+
+    /**
+     * Pass True, if the uploaded video is suitable for streaming
+     */
+    supports_streaming?: boolean,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method to send animation files (GIF or H.264/MPEG-4 AVC video 
+   * without sound). On success, the sent Message is returned. Bots can 
+   * currently send animation files of up to 50 MB in size, this limit may be 
+   * changed in the future.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendAnimationPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Animation to send. Pass a file_id as String to send an animation that 
+     * exists on the Telegram servers (recommended), pass an HTTP URL as a 
+     * String for Telegram to get an animation from the Internet, or upload a 
+     * new animation using multipart/form-data. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    animation: InputFile | string,
+
+    /**
+     * Duration of sent animation in seconds
+     */
+    duration?: number,
+
+    /**
+     * Animation width
+     */
+    width?: number,
+
+    /**
+     * Animation height
+     */
+    height?: number,
+
+    /**
+     * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+     * the file is supported server-side. The thumbnail should be in JPEG 
+     * format and less than 200 kB in size. A thumbnail's width and height 
+     * should not exceed 320. Ignored if the file is not uploaded using 
+     * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
+     * as a new file, so you can pass “attach://<file_attach_name>” if the 
+     * thumbnail was uploaded using multipart/form-data under 
+     * <file_attach_name>. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    thumb?: InputFile | string,
+
+    /**
+     * Animation caption (may also be used when resending animation by 
+     * file_id), 0-1024 characters after entities parsing
+     */
+    caption?: string,
+
+    /**
+     * Mode for parsing entities in the animation caption. See formatting 
+     * options for more details.
+     * @see https://core.telegram.org/bots/api#formatting-options
+     */
+    parse_mode?: string,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method to send audio files, if you want Telegram clients to 
+   * display the file as a playable voice message. For this to work, your 
+   * audio must be in an .OGG file encoded with OPUS (other formats may be 
+   * sent as Audio or Document). On success, the sent Message is returned. 
+   * Bots can currently send voice messages of up to 50 MB in size, this 
+   * limit may be changed in the future.
+   * @see https://core.telegram.org/bots/api#audio
+   * @see https://core.telegram.org/bots/api#document
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendVoicePayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Audio file to send. Pass a file_id as String to send a file that exists 
+     * on the Telegram servers (recommended), pass an HTTP URL as a String for 
+     * Telegram to get a file from the Internet, or upload a new one using 
+     * multipart/form-data. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    voice: InputFile | string,
+
+    /**
+     * Voice message caption, 0-1024 characters after entities parsing
+     */
+    caption?: string,
+
+    /**
+     * Mode for parsing entities in the voice message caption. See formatting 
+     * options for more details.
+     * @see https://core.telegram.org/bots/api#formatting-options
+     */
+    parse_mode?: string,
+
+    /**
+     * Duration of the voice message in seconds
+     */
+    duration?: number,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * As of v.4.0, Telegram clients support rounded square mp4 videos of up to 
+   * 1 minute long. Use this method to send video messages. On success, the 
+   * sent Message is returned.
+   * @see https://telegram.org/blog/video-messages-and-telescope
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendVideoNotePayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Video note to send. Pass a file_id as String to send a video note that 
+     * exists on the Telegram servers (recommended) or upload a new video using 
+     * multipart/form-data. More info on Sending Files ». Sending video notes 
+     * by a URL is currently unsupported
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    video_note: InputFile | string,
+
+    /**
+     * Duration of sent video in seconds
+     */
+    duration?: number,
+
+    /**
+     * Video width and height, i.e. diameter of the video message
+     */
+    length?: number,
+
+    /**
+     * Thumbnail of the file sent; can be ignored if thumbnail generation for 
+     * the file is supported server-side. The thumbnail should be in JPEG 
+     * format and less than 200 kB in size. A thumbnail's width and height 
+     * should not exceed 320. Ignored if the file is not uploaded using 
+     * multipart/form-data. Thumbnails can't be reused and can be only uploaded 
+     * as a new file, so you can pass “attach://<file_attach_name>” if the 
+     * thumbnail was uploaded using multipart/form-data under 
+     * <file_attach_name>. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    thumb?: InputFile | string,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method to send a group of photos or videos as an album. On 
+   * success, an array of the sent Messages is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendMediaGroupPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * A JSON-serialized array describing photos and videos to be sent, must 
+     * include 2-10 items
+     */
+    media: (InputMediaPhoto | InputMediaVideo)[][],
+
+    /**
+     * Sends the messages silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the messages are a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+  };
+
+  /**
+   * Use this method to send point on the map. On success, the sent Message 
+   * is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendLocationPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Latitude of the location
+     */
+    latitude: number,
+
+    /**
+     * Longitude of the location
+     */
+    longitude: number,
+
+    /**
+     * Period in seconds for which the location will be updated (see Live 
+     * Locations, should be between 60 and 86400.
+     * @see https://telegram.org/blog/live-locations
+     */
+    live_period?: number,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method to edit live location messages. A location can be edited 
+   * until its live_period expires or editing is explicitly disabled by a 
+   * call to stopMessageLiveLocation. On success, if the edited message was 
+   * sent by the bot, the edited Message is returned, otherwise True is returned.
+   * @see https://core.telegram.org/bots/api#stopmessagelivelocation
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type EditMessageLiveLocationPayload = {
+    /**
+     * Required if inline_message_id is not specified. Unique identifier for 
+     * the target chat or username of the target channel (in the format @channelusername)
+     */
+    chat_id?: number | string,
+
+    /**
+     * Required if inline_message_id is not specified. Identifier of the 
+     * message to edit
+     */
+    message_id?: number,
+
+    /**
+     * Required if chat_id and message_id are not specified. Identifier of the 
+     * inline message
+     */
+    inline_message_id?: string,
+
+    /**
+     * Latitude of new location
+     */
+    latitude: number,
+
+    /**
+     * Longitude of new location
+     */
+    longitude: number,
+
+    /**
+     * A JSON-serialized object for a new inline keyboard.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     */
+    reply_markup?: InlineKeyboardMarkup,
+  };
+
+  /**
+   * Use this method to stop updating a live location message before 
+   * live_period expires. On success, if the message was sent by the bot, the 
+   * sent Message is returned, otherwise True is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type StopMessageLiveLocationPayload = {
+    /**
+     * Required if inline_message_id is not specified. Unique identifier for 
+     * the target chat or username of the target channel (in the format @channelusername)
+     */
+    chat_id?: number | string,
+
+    /**
+     * Required if inline_message_id is not specified. Identifier of the 
+     * message with live location to stop
+     */
+    message_id?: number,
+
+    /**
+     * Required if chat_id and message_id are not specified. Identifier of the 
+     * inline message
+     */
+    inline_message_id?: string,
+
+    /**
+     * A JSON-serialized object for a new inline keyboard.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     */
+    reply_markup?: InlineKeyboardMarkup,
+  };
+
+  /**
+   * Use this method to send information about a venue. On success, the sent 
+   * Message is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendVenuePayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Latitude of the venue
+     */
+    latitude: number,
+
+    /**
+     * Longitude of the venue
+     */
+    longitude: number,
+
+    /**
+     * Name of the venue
+     */
+    title: string,
+
+    /**
+     * Address of the venue
+     */
+    address: string,
+
+    /**
+     * Foursquare identifier of the venue
+     */
+    foursquare_id?: string,
+
+    /**
+     * Foursquare type of the venue, if known. (For example, 
+     * “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
+     */
+    foursquare_type?: string,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method to send phone contacts. On success, the sent Message is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendContactPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Contact's phone number
+     */
+    phone_number: string,
+
+    /**
+     * Contact's first name
+     */
+    first_name: string,
+
+    /**
+     * Contact's last name
+     */
+    last_name?: string,
+
+    /**
+     * Additional data about the contact in the form of a vCard, 0-2048 bytes
+     * @see https://en.wikipedia.org/wiki/VCard
+     */
+    vcard?: string,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove keyboard or to 
+     * force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method to send a native poll. On success, the sent Message is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendPollPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Poll question, 1-255 characters
+     */
+    question: string,
+
+    /**
+     * A JSON-serialized list of answer options, 2-10 strings 1-100 characters each
+     */
+    options: string[],
+
+    /**
+     * True, if the poll needs to be anonymous, defaults to True
+     */
+    is_anonymous?: boolean,
+
+    /**
+     * Poll type, “quiz” or “regular”, defaults to “regular”
+     */
+    type?: string,
+
+    /**
+     * True, if the poll allows multiple answers, ignored for polls in quiz 
+     * mode, defaults to False
+     */
+    allows_multiple_answers?: boolean,
+
+    /**
+     * 0-based identifier of the correct answer option, required for polls in 
+     * quiz mode
+     */
+    correct_option_id?: number,
+
+    /**
+     * Text that is shown when a user chooses an incorrect answer or taps on 
+     * the lamp icon in a quiz-style poll, 0-200 characters with at most 2 line 
+     * feeds after entities parsing
+     */
+    explanation?: string,
+
+    /**
+     * Mode for parsing entities in the explanation. See formatting options for 
+     * more details.
+     * @see https://core.telegram.org/bots/api#formatting-options
+     */
+    explanation_parse_mode?: string,
+
+    /**
+     * Amount of time in seconds the poll will be active after creation, 5-600. 
+     * Can't be used together with close_date.
+     */
+    open_period?: number,
+
+    /**
+     * Point in time (Unix timestamp) when the poll will be automatically 
+     * closed. Must be at least 5 and no more than 600 seconds in the future. 
+     * Can't be used together with open_period.
+     */
+    close_date?: number,
+
+    /**
+     * Pass True, if the poll needs to be immediately closed. This can be 
+     * useful for poll preview.
+     */
+    is_closed?: boolean,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method to send an animated emoji that will display a random 
+   * value. On success, the sent Message is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendDicePayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Emoji on which the dice throw animation is based. Currently, must be one 
+     * of “”, “”, or “”. Dice can have values 1-6 for “” and “”, and values 1-5 
+     * for “”. Defaults to “”
+     */
+    emoji?: string,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method when you need to tell the user that something is 
+   * happening on the bot's side. The status is set for 5 seconds or less 
+   * (when a message arrives from your bot, Telegram clients clear its typing 
+   * status). Returns True on success.
+   */
+  declare type SendChatActionPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Type of action to broadcast. Choose one, depending on what the user is 
+     * about to receive: typing for text messages, upload_photo for photos, 
+     * record_video or upload_video for videos, record_audio or upload_audio 
+     * for audio files, upload_document for general files, find_location for 
+     * location data, record_video_note or upload_video_note for video notes.
+     * @see https://core.telegram.org/bots/api#sendmessage
+     * @see https://core.telegram.org/bots/api#sendphoto
+     * @see https://core.telegram.org/bots/api#sendvideo
+     * @see https://core.telegram.org/bots/api#sendaudio
+     * @see https://core.telegram.org/bots/api#senddocument
+     * @see https://core.telegram.org/bots/api#sendlocation
+     * @see https://core.telegram.org/bots/api#sendvideonote
+     */
+    action: string,
+  };
+
+  /**
+   * Use this method to get a list of profile pictures for a user. Returns a 
+   * UserProfilePhotos object.
+   * @see https://core.telegram.org/bots/api#userprofilephotos
+   */
+  declare type GetUserProfilePhotosPayload = {
+    /**
+     * Unique identifier of the target user
+     */
+    user_id: number,
+
+    /**
+     * Sequential number of the first photo to be returned. By default, all 
+     * photos are returned.
+     */
+    offset?: number,
+
+    /**
+     * Limits the number of photos to be retrieved. Values between 1-100 are 
+     * accepted. Defaults to 100.
+     */
+    limit?: number,
+  };
+
+  /**
+   * Use this method to get basic info about a file and prepare it for 
+   * downloading. For the moment, bots can download files of up to 20MB in 
+   * size. On success, a File object is returned. The file can then be 
+   * downloaded via the link 
+   * https://api.telegram.org/file/bot<token>/<file_path>, where <file_path> 
+   * is taken from the response. It is guaranteed that the link will be valid 
+   * for at least 1 hour. When the link expires, a new one can be requested 
+   * by calling getFile again.
+   * @see https://core.telegram.org/bots/api#file
+   * @see https://core.telegram.org/bots/api#getfile
+   */
+  declare type GetFilePayload = {
+    /**
+     * File identifier to get info about
+     */
+    file_id: string
+  };
+
+  /**
+   * Use this method to kick a user from a group, a supergroup or a channel. 
+   * In the case of supergroups and channels, the user will not be able to 
+   * return to the group on their own using invite links, etc., unless 
+   * unbanned first. The bot must be an administrator in the chat for this to 
+   * work and must have the appropriate admin rights. Returns True on success.
+   * @see https://core.telegram.org/bots/api#unbanchatmember
+   */
+  declare type KickChatMemberPayload = {
+    /**
+     * Unique identifier for the target group or username of the target 
+     * supergroup or channel (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Unique identifier of the target user
+     */
+    user_id: number,
+
+    /**
+     * Date when the user will be unbanned, unix time. If user is banned for 
+     * more than 366 days or less than 30 seconds from the current time they 
+     * are considered to be banned forever
+     */
+    until_date?: number,
+  };
+
+  /**
+   * Use this method to unban a previously kicked user in a supergroup or 
+   * channel. The user will not return to the group or channel automatically, 
+   * but will be able to join via link, etc. The bot must be an administrator 
+   * for this to work. Returns True on success.
+   */
+  declare type UnbanChatMemberPayload = {
+    /**
+     * Unique identifier for the target group or username of the target 
+     * supergroup or channel (in the format @username)
+     */
+    chat_id: number | string,
+
+    /**
+     * Unique identifier of the target user
+     */
+    user_id: number,
+  };
+
+  /**
+   * Use this method to restrict a user in a supergroup. The bot must be an 
+   * administrator in the supergroup for this to work and must have the 
+   * appropriate admin rights. Pass True for all permissions to lift 
+   * restrictions from a user. Returns True on success.
+   */
+  declare type RestrictChatMemberPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target 
+     * supergroup (in the format @supergroupusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Unique identifier of the target user
+     */
+    user_id: number,
+
+    /**
+     * A JSON-serialized object for new user permissions
+     */
+    permissions: ChatPermissions,
+
+    /**
+     * Date when restrictions will be lifted for the user, unix time. If user 
+     * is restricted for more than 366 days or less than 30 seconds from the 
+     * current time, they are considered to be restricted forever
+     */
+    until_date?: number,
+  };
+
+  /**
+   * Use this method to promote or demote a user in a supergroup or a 
+   * channel. The bot must be an administrator in the chat for this to work 
+   * and must have the appropriate admin rights. Pass False for all boolean 
+   * parameters to demote a user. Returns True on success.
+   */
+  declare type PromoteChatMemberPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Unique identifier of the target user
+     */
+    user_id: number,
+
+    /**
+     * Pass True, if the administrator can change chat title, photo and other settings
+     */
+    can_change_info?: boolean,
+
+    /**
+     * Pass True, if the administrator can create channel posts, channels only
+     */
+    can_post_messages?: boolean,
+
+    /**
+     * Pass True, if the administrator can edit messages of other users and can 
+     * pin messages, channels only
+     */
+    can_edit_messages?: boolean,
+
+    /**
+     * Pass True, if the administrator can delete messages of other users
+     */
+    can_delete_messages?: boolean,
+
+    /**
+     * Pass True, if the administrator can invite new users to the chat
+     */
+    can_invite_users?: boolean,
+
+    /**
+     * Pass True, if the administrator can restrict, ban or unban chat members
+     */
+    can_restrict_members?: boolean,
+
+    /**
+     * Pass True, if the administrator can pin messages, supergroups only
+     */
+    can_pin_messages?: boolean,
+
+    /**
+     * Pass True, if the administrator can add new administrators with a subset 
+     * of their own privileges or demote administrators that he has promoted, 
+     * directly or indirectly (promoted by administrators that were appointed 
+     * by him)
+     */
+    can_promote_members?: boolean,
+  };
+
+  /**
+   * Use this method to set a custom title for an administrator in a 
+   * supergroup promoted by the bot. Returns True on success.
+   */
+  declare type SetChatAdministratorCustomTitlePayload = {
+    /**
+     * Unique identifier for the target chat or username of the target 
+     * supergroup (in the format @supergroupusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Unique identifier of the target user
+     */
+    user_id: number,
+
+    /**
+     * New custom title for the administrator; 0-16 characters, emoji are not allowed
+     */
+    custom_title: string,
+  };
+
+  /**
+   * Use this method to set default chat permissions for all members. The bot 
+   * must be an administrator in the group or a supergroup for this to work 
+   * and must have the can_restrict_members admin rights. Returns True on success.
+   */
+  declare type SetChatPermissionsPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target 
+     * supergroup (in the format @supergroupusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * New default chat permissions
+     */
+    permissions: ChatPermissions,
+  };
+
+  /**
+   * Use this method to generate a new invite link for a chat; any previously 
+   * generated link is revoked. The bot must be an administrator in the chat 
+   * for this to work and must have the appropriate admin rights. Returns the 
+   * new invite link as String on success.
+   */
+  declare type ExportChatInviteLinkPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string
+  };
+
+  /**
+   * Use this method to set a new profile photo for the chat. Photos can't be 
+   * changed for private chats. The bot must be an administrator in the chat 
+   * for this to work and must have the appropriate admin rights. Returns 
+   * True on success.
+   */
+  declare type SetChatPhotoPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * New chat photo, uploaded using multipart/form-data
+     */
+    photo: InputFile,
+  };
+
+  /**
+   * Use this method to delete a chat photo. Photos can't be changed for 
+   * private chats. The bot must be an administrator in the chat for this to 
+   * work and must have the appropriate admin rights. Returns True on success.
+   */
+  declare type DeleteChatPhotoPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string
+  };
+
+  /**
+   * Use this method to change the title of a chat. Titles can't be changed 
+   * for private chats. The bot must be an administrator in the chat for this 
+   * to work and must have the appropriate admin rights. Returns True on success.
+   */
+  declare type SetChatTitlePayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * New chat title, 1-255 characters
+     */
+    title: string,
+  };
+
+  /**
+   * Use this method to change the description of a group, a supergroup or a 
+   * channel. The bot must be an administrator in the chat for this to work 
+   * and must have the appropriate admin rights. Returns True on success.
+   */
+  declare type SetChatDescriptionPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * New chat description, 0-255 characters
+     */
+    description?: string,
+  };
+
+  /**
+   * Use this method to pin a message in a group, a supergroup, or a channel. 
+   * The bot must be an administrator in the chat for this to work and must 
+   * have the 'can_pin_messages' admin right in the supergroup or 
+   * 'can_edit_messages' admin right in the channel. Returns True on success.
+   */
+  declare type PinChatMessagePayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Identifier of a message to pin
+     */
+    message_id: number,
+
+    /**
+     * Pass True, if it is not necessary to send a notification to all chat 
+     * members about the new pinned message. Notifications are always disabled 
+     * in channels.
+     */
+    disable_notification?: boolean,
+  };
+
+  /**
+   * Use this method to unpin a message in a group, a supergroup, or a 
+   * channel. The bot must be an administrator in the chat for this to work 
+   * and must have the 'can_pin_messages' admin right in the supergroup or 
+   * 'can_edit_messages' admin right in the channel. Returns True on success.
+   */
+  declare type UnpinChatMessagePayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string
+  };
+
+  /**
+   * Use this method for your bot to leave a group, supergroup or channel. 
+   * Returns True on success.
+   */
+  declare type LeaveChatPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target 
+     * supergroup or channel (in the format @channelusername)
+     */
+    chat_id: number | string
+  };
+
+  /**
+   * Use this method to get up to date information about the chat (current 
+   * name of the user for one-on-one conversations, current username of a 
+   * user, group or channel, etc.). Returns a Chat object on success.
+   * @see https://core.telegram.org/bots/api#chat
+   */
+  declare type GetChatPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target 
+     * supergroup or channel (in the format @channelusername)
+     */
+    chat_id: number | string
+  };
+
+  /**
+   * Use this method to get a list of administrators in a chat. On success, 
+   * returns an Array of ChatMember objects that contains information about 
+   * all chat administrators except other bots. If the chat is a group or a 
+   * supergroup and no administrators were appointed, only the creator will 
+   * be returned.
+   * @see https://core.telegram.org/bots/api#chatmember
+   */
+  declare type GetChatAdministratorsPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target 
+     * supergroup or channel (in the format @channelusername)
+     */
+    chat_id: number | string
+  };
+
+  /**
+   * Use this method to get the number of members in a chat. Returns Int on success.
+   */
+  declare type GetChatMembersCountPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target 
+     * supergroup or channel (in the format @channelusername)
+     */
+    chat_id: number | string
+  };
+
+  /**
+   * Use this method to get information about a member of a chat. Returns a 
+   * ChatMember object on success.
+   * @see https://core.telegram.org/bots/api#chatmember
+   */
+  declare type GetChatMemberPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target 
+     * supergroup or channel (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Unique identifier of the target user
+     */
+    user_id: number,
+  };
+
+  /**
+   * Use this method to set a new group sticker set for a supergroup. The bot 
+   * must be an administrator in the chat for this to work and must have the 
+   * appropriate admin rights. Use the field can_set_sticker_set optionally 
+   * returned in getChat requests to check if the bot can use this method. 
+   * Returns True on success.
+   * @see https://core.telegram.org/bots/api#getchat
+   */
+  declare type SetChatStickerSetPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target 
+     * supergroup (in the format @supergroupusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Name of the sticker set to be set as the group sticker set
+     */
+    sticker_set_name: string,
+  };
+
+  /**
+   * Use this method to delete a group sticker set from a supergroup. The bot 
+   * must be an administrator in the chat for this to work and must have the 
+   * appropriate admin rights. Use the field can_set_sticker_set optionally 
+   * returned in getChat requests to check if the bot can use this method. 
+   * Returns True on success.
+   * @see https://core.telegram.org/bots/api#getchat
+   */
+  declare type DeleteChatStickerSetPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target 
+     * supergroup (in the format @supergroupusername)
+     */
+    chat_id: number | string
+  };
+
+  /**
+   * Use this method to send answers to callback queries sent from inline 
+   * keyboards. The answer will be displayed to the user as a notification at 
+   * the top of the chat screen or as an alert. On success, True is returned.
+   * @see https://core.telegram.org/bots/api/bots#inline-keyboards-and-on-the-fly-updating
+   */
+  declare type AnswerCallbackQueryPayload = {
+    /**
+     * Unique identifier for the query to be answered
+     */
+    callback_query_id: string,
+
+    /**
+     * Text of the notification. If not specified, nothing will be shown to the 
+     * user, 0-200 characters
+     */
+    text?: string,
+
+    /**
+     * If true, an alert will be shown by the client instead of a notification 
+     * at the top of the chat screen. Defaults to false.
+     */
+    show_alert?: boolean,
+
+    /**
+     * URL that will be opened by the user's client. If you have created a Game 
+     * and accepted the conditions via @Botfather, specify the URL that opens 
+     * your game — note that this will only work if the query comes from a 
+     * callback_game button.Otherwise, you may use links like 
+     * t.me/your_bot?start=XXXX that open your bot with a parameter.
+     * @see https://core.telegram.org/bots/api#game
+     * @see https://t.me/botfather
+     * @see https://core.telegram.org/bots/api#inlinekeyboardbutton
+     */
+    url?: string,
+
+    /**
+     * The maximum amount of time in seconds that the result of the callback 
+     * query may be cached client-side. Telegram apps will support caching 
+     * starting in version 3.14. Defaults to 0.
+     */
+    cache_time?: number,
+  };
+
+  /**
+   * Use this method to change the list of the bot's commands. Returns True 
+   * on success.
+   */
+  declare type SetMyCommandsPayload = {
+    /**
+     * A JSON-serialized list of bot commands to be set as the list of the 
+     * bot's commands. At most 100 commands can be specified.
+     */
+    commands: BotCommand[]
+  };
+
+  /**
+   * Use this method to edit text and game messages. On success, if edited 
+   * message is sent by the bot, the edited Message is returned, otherwise 
+   * True is returned.
+   * @see https://core.telegram.org/bots/api#games
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type EditMessageTextPayload = {
+    /**
+     * Required if inline_message_id is not specified. Unique identifier for 
+     * the target chat or username of the target channel (in the format @channelusername)
+     */
+    chat_id?: number | string,
+
+    /**
+     * Required if inline_message_id is not specified. Identifier of the 
+     * message to edit
+     */
+    message_id?: number,
+
+    /**
+     * Required if chat_id and message_id are not specified. Identifier of the 
+     * inline message
+     */
+    inline_message_id?: string,
+
+    /**
+     * New text of the message, 1-4096 characters after entities parsing
+     */
+    text: string,
+
+    /**
+     * Mode for parsing entities in the message text. See formatting options 
+     * for more details.
+     * @see https://core.telegram.org/bots/api#formatting-options
+     */
+    parse_mode?: string,
+
+    /**
+     * Disables link previews for links in this message
+     */
+    disable_web_page_preview?: boolean,
+
+    /**
+     * A JSON-serialized object for an inline keyboard.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     */
+    reply_markup?: InlineKeyboardMarkup,
+  };
+
+  /**
+   * Use this method to edit captions of messages. On success, if edited 
+   * message is sent by the bot, the edited Message is returned, otherwise 
+   * True is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type EditMessageCaptionPayload = {
+    /**
+     * Required if inline_message_id is not specified. Unique identifier for 
+     * the target chat or username of the target channel (in the format @channelusername)
+     */
+    chat_id?: number | string,
+
+    /**
+     * Required if inline_message_id is not specified. Identifier of the 
+     * message to edit
+     */
+    message_id?: number,
+
+    /**
+     * Required if chat_id and message_id are not specified. Identifier of the 
+     * inline message
+     */
+    inline_message_id?: string,
+
+    /**
+     * New caption of the message, 0-1024 characters after entities parsing
+     */
+    caption?: string,
+
+    /**
+     * Mode for parsing entities in the message caption. See formatting options 
+     * for more details.
+     * @see https://core.telegram.org/bots/api#formatting-options
+     */
+    parse_mode?: string,
+
+    /**
+     * A JSON-serialized object for an inline keyboard.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     */
+    reply_markup?: InlineKeyboardMarkup,
+  };
+
+  /**
+   * Use this method to edit animation, audio, document, photo, or video 
+   * messages. If a message is a part of a message album, then it can be 
+   * edited only to a photo or a video. Otherwise, message type can be 
+   * changed arbitrarily. When inline message is edited, new file can't be 
+   * uploaded. Use previously uploaded file via its file_id or specify a URL. 
+   * On success, if the edited message was sent by the bot, the edited 
+   * Message is returned, otherwise True is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type EditMessageMediaPayload = {
+    /**
+     * Required if inline_message_id is not specified. Unique identifier for 
+     * the target chat or username of the target channel (in the format @channelusername)
+     */
+    chat_id?: number | string,
+
+    /**
+     * Required if inline_message_id is not specified. Identifier of the 
+     * message to edit
+     */
+    message_id?: number,
+
+    /**
+     * Required if chat_id and message_id are not specified. Identifier of the 
+     * inline message
+     */
+    inline_message_id?: string,
+
+    /**
+     * A JSON-serialized object for a new media content of the message
+     */
+    media: InputMedia,
+
+    /**
+     * A JSON-serialized object for a new inline keyboard.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     */
+    reply_markup?: InlineKeyboardMarkup,
+  };
+
+  /**
+   * Use this method to edit only the reply markup of messages. On success, 
+   * if edited message is sent by the bot, the edited Message is returned, 
+   * otherwise True is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type EditMessageReplyMarkupPayload = {
+    /**
+     * Required if inline_message_id is not specified. Unique identifier for 
+     * the target chat or username of the target channel (in the format @channelusername)
+     */
+    chat_id?: number | string,
+
+    /**
+     * Required if inline_message_id is not specified. Identifier of the 
+     * message to edit
+     */
+    message_id?: number,
+
+    /**
+     * Required if chat_id and message_id are not specified. Identifier of the 
+     * inline message
+     */
+    inline_message_id?: string,
+
+    /**
+     * A JSON-serialized object for an inline keyboard.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     */
+    reply_markup?: InlineKeyboardMarkup,
+  };
+
+  /**
+   * Use this method to stop a poll which was sent by the bot. On success, 
+   * the stopped Poll with the final results is returned.
+   * @see https://core.telegram.org/bots/api#poll
+   */
+  declare type StopPollPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Identifier of the original message with the poll
+     */
+    message_id: number,
+
+    /**
+     * A JSON-serialized object for a new message inline keyboard.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     */
+    reply_markup?: InlineKeyboardMarkup,
+  };
+
+  /**
+   * Use this method to delete a message, including service messages, with 
+   * the following limitations:- A message can only be deleted if it was sent 
+   * less than 48 hours ago.- A dice message in a private chat can only be 
+   * deleted if it was sent more than 24 hours ago.- Bots can delete outgoing 
+   * messages in private chats, groups, and supergroups.- Bots can delete 
+   * incoming messages in private chats.- Bots granted can_post_messages 
+   * permissions can delete outgoing messages in channels.- If the bot is an 
+   * administrator of a group, it can delete any message there.- If the bot 
+   * has can_delete_messages permission in a supergroup or a channel, it can 
+   * delete any message there.Returns True on success.
+   */
+  declare type DeleteMessagePayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Identifier of the message to delete
+     */
+    message_id: number,
   };
 
   /**
@@ -1598,9 +3967,15 @@ declare module "telegram-typings" {
    */
   declare type Sticker = {
     /**
-     * Unique identifier for this file
+     * Identifier for this file, which can be used to download or reuse the file
      */
     file_id: string,
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over 
+     * time and for different bots. Can't be used to download or reuse the file.
+     */
+    file_unique_id: string,
 
     /**
      * Sticker width
@@ -1613,7 +3988,13 @@ declare module "telegram-typings" {
     height: number,
 
     /**
-     * Sticker thumbnail in the .webp or .jpg format
+     * True, if the sticker is animated
+     * @see https://telegram.org/blog/animated-stickers
+     */
+    is_animated: boolean,
+
+    /**
+     * Sticker thumbnail in the .WEBP or .JPG format
      */
     thumb?: PhotoSize,
 
@@ -1653,6 +4034,12 @@ declare module "telegram-typings" {
     title: string,
 
     /**
+     * True, if the sticker set contains animated stickers
+     * @see https://telegram.org/blog/animated-stickers
+     */
+    is_animated: boolean,
+
+    /**
      * True, if the sticker set contains masks
      */
     contains_masks: boolean,
@@ -1661,6 +4048,11 @@ declare module "telegram-typings" {
      * List of all set stickers
      */
     stickers: Sticker[],
+
+    /**
+     * Sticker set thumbnail in the .WEBP or .TGS format
+     */
+    thumb?: PhotoSize,
   };
 
   /**
@@ -1695,6 +4087,246 @@ declare module "telegram-typings" {
   };
 
   /**
+   * Use this method to send static .WEBP or animated .TGS stickers. On 
+   * success, the sent Message is returned.
+   * @see https://telegram.org/blog/animated-stickers
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendStickerPayload = {
+    /**
+     * Unique identifier for the target chat or username of the target channel 
+     * (in the format @channelusername)
+     */
+    chat_id: number | string,
+
+    /**
+     * Sticker to send. Pass a file_id as String to send a file that exists on 
+     * the Telegram servers (recommended), pass an HTTP URL as a String for 
+     * Telegram to get a .WEBP file from the Internet, or upload a new one 
+     * using multipart/form-data. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    sticker: InputFile | string,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * Additional interface options. A JSON-serialized object for an inline 
+     * keyboard, custom reply keyboard, instructions to remove reply keyboard 
+     * or to force a reply from the user.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     * @see https://core.telegram.org/bots#keyboards
+     */
+    reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply,
+  };
+
+  /**
+   * Use this method to get a sticker set. On success, a StickerSet object is returned.
+   * @see https://core.telegram.org/bots/api#stickerset
+   */
+  declare type GetStickerSetPayload = {
+    /**
+     * Name of the sticker set
+     */
+    name: string
+  };
+
+  /**
+   * Use this method to upload a .PNG file with a sticker for later use in 
+   * createNewStickerSet and addStickerToSet methods (can be used multiple 
+   * times). Returns the uploaded File on success.
+   * @see https://core.telegram.org/bots/api#file
+   */
+  declare type UploadStickerFilePayload = {
+    /**
+     * User identifier of sticker file owner
+     */
+    user_id: number,
+
+    /**
+     * PNG image with the sticker, must be up to 512 kilobytes in size, 
+     * dimensions must not exceed 512px, and either width or height must be 
+     * exactly 512px. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    png_sticker: InputFile,
+  };
+
+  /**
+   * Use this method to create a new sticker set owned by a user. The bot 
+   * will be able to edit the sticker set thus created. You must use exactly 
+   * one of the fields png_sticker or tgs_sticker. Returns True on success.
+   */
+  declare type CreateNewStickerSetPayload = {
+    /**
+     * User identifier of created sticker set owner
+     */
+    user_id: number,
+
+    /**
+     * Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., 
+     * animals). Can contain only english letters, digits and underscores. Must 
+     * begin with a letter, can't contain consecutive underscores and must end 
+     * in “_by_<bot username>”. <bot_username> is case insensitive. 1-64 characters.
+     */
+    name: string,
+
+    /**
+     * Sticker set title, 1-64 characters
+     */
+    title: string,
+
+    /**
+     * PNG image with the sticker, must be up to 512 kilobytes in size, 
+     * dimensions must not exceed 512px, and either width or height must be 
+     * exactly 512px. Pass a file_id as a String to send a file that already 
+     * exists on the Telegram servers, pass an HTTP URL as a String for 
+     * Telegram to get a file from the Internet, or upload a new one using 
+     * multipart/form-data. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    png_sticker?: InputFile | string,
+
+    /**
+     * TGS animation with the sticker, uploaded using multipart/form-data. See 
+     * https://core.telegram.org/animated_stickers#technical-requirements for 
+     * technical requirements
+     * @see https://core.telegram.org/animated_stickers#technical-requirements
+     */
+    tgs_sticker?: InputFile,
+
+    /**
+     * One or more emoji corresponding to the sticker
+     */
+    emojis: string,
+
+    /**
+     * Pass True, if a set of mask stickers should be created
+     */
+    contains_masks?: boolean,
+
+    /**
+     * A JSON-serialized object for position where the mask should be placed on faces
+     */
+    mask_position?: MaskPosition,
+  };
+
+  /**
+   * Use this method to add a new sticker to a set created by the bot. You 
+   * must use exactly one of the fields png_sticker or tgs_sticker. Animated 
+   * stickers can be added to animated sticker sets and only to them. 
+   * Animated sticker sets can have up to 50 stickers. Static sticker sets 
+   * can have up to 120 stickers. Returns True on success.
+   */
+  declare type AddStickerToSetPayload = {
+    /**
+     * User identifier of sticker set owner
+     */
+    user_id: number,
+
+    /**
+     * Sticker set name
+     */
+    name: string,
+
+    /**
+     * PNG image with the sticker, must be up to 512 kilobytes in size, 
+     * dimensions must not exceed 512px, and either width or height must be 
+     * exactly 512px. Pass a file_id as a String to send a file that already 
+     * exists on the Telegram servers, pass an HTTP URL as a String for 
+     * Telegram to get a file from the Internet, or upload a new one using 
+     * multipart/form-data. More info on Sending Files »
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    png_sticker?: InputFile | string,
+
+    /**
+     * TGS animation with the sticker, uploaded using multipart/form-data. See 
+     * https://core.telegram.org/animated_stickers#technical-requirements for 
+     * technical requirements
+     * @see https://core.telegram.org/animated_stickers#technical-requirements
+     */
+    tgs_sticker?: InputFile,
+
+    /**
+     * One or more emoji corresponding to the sticker
+     */
+    emojis: string,
+
+    /**
+     * A JSON-serialized object for position where the mask should be placed on faces
+     */
+    mask_position?: MaskPosition,
+  };
+
+  /**
+   * Use this method to move a sticker in a set created by the bot to a 
+   * specific position. Returns True on success.
+   */
+  declare type SetStickerPositionInSetPayload = {
+    /**
+     * File identifier of the sticker
+     */
+    sticker: string,
+
+    /**
+     * New sticker position in the set, zero-based
+     */
+    position: number,
+  };
+
+  /**
+   * Use this method to delete a sticker from a set created by the bot. 
+   * Returns True on success.
+   */
+  declare type DeleteStickerFromSetPayload = {
+    /**
+     * File identifier of the sticker
+     */
+    sticker: string
+  };
+
+  /**
+   * Use this method to set the thumbnail of a sticker set. Animated 
+   * thumbnails can be set for animated sticker sets only. Returns True on success.
+   */
+  declare type SetStickerSetThumbPayload = {
+    /**
+     * Sticker set name
+     */
+    name: string,
+
+    /**
+     * User identifier of the sticker set owner
+     */
+    user_id: number,
+
+    /**
+     * A PNG image with the thumbnail, must be up to 128 kilobytes in size and 
+     * have width and height exactly 100px, or a TGS animation with the 
+     * thumbnail up to 32 kilobytes in size; see 
+     * https://core.telegram.org/animated_stickers#technical-requirements for 
+     * animated sticker technical requirements. Pass a file_id as a String to 
+     * send a file that already exists on the Telegram servers, pass an HTTP 
+     * URL as a String for Telegram to get a file from the Internet, or upload 
+     * a new one using multipart/form-data. More info on Sending Files ». 
+     * Animated sticker set thumbnail can't be uploaded via HTTP URL.
+     * @see https://core.telegram.org/animated_stickers#technical-requirements
+     * @see https://core.telegram.org/bots/api#sending-files
+     */
+    thumb?: InputFile | string,
+  };
+
+  /**
    * This object represents an incoming inline query. When the user sends an 
    * empty query, your bot could return some default or trending results.
    */
@@ -1715,7 +4347,7 @@ declare module "telegram-typings" {
     location?: Location,
 
     /**
-     * Text of the query (up to 512 characters)
+     * Text of the query (up to 256 characters)
      */
     query: string,
 
@@ -1723,6 +4355,66 @@ declare module "telegram-typings" {
      * Offset of the results to be returned, can be controlled by the bot
      */
     offset: string,
+  };
+
+  /**
+   * Use this method to send answers to an inline query. On success, True is 
+   * returned.No more than 50 results per query are allowed.
+   */
+  declare type AnswerInlineQueryPayload = {
+    /**
+     * Unique identifier for the answered query
+     */
+    inline_query_id: string,
+
+    /**
+     * A JSON-serialized array of results for the inline query
+     */
+    results: InlineQueryResult[],
+
+    /**
+     * The maximum amount of time in seconds that the result of the inline 
+     * query may be cached on the server. Defaults to 300.
+     */
+    cache_time?: number,
+
+    /**
+     * Pass True, if results may be cached on the server side only for the user 
+     * that sent the query. By default, results may be returned to any user who 
+     * sends the same query
+     */
+    is_personal?: boolean,
+
+    /**
+     * Pass the offset that a client should send in the next query with the 
+     * same text to receive more results. Pass an empty string if there are no 
+     * more results or if you don't support pagination. Offset length can't 
+     * exceed 64 bytes.
+     */
+    next_offset?: string,
+
+    /**
+     * If passed, clients will display a button with specified text that 
+     * switches the user to a private chat with the bot and sends the bot a 
+     * start message with the parameter switch_pm_parameter
+     */
+    switch_pm_text?: string,
+
+    /**
+     * Deep-linking parameter for the /start message sent to the bot when user 
+     * presses the switch button. 1-64 characters, only A-Z, a-z, 0-9, _ and - 
+     * are allowed.Example: An inline bot that sends YouTube videos can ask the 
+     * user to connect the bot to their YouTube account to adapt search results 
+     * accordingly. To do this, it displays a 'Connect your YouTube account' 
+     * button above the results, or even before showing any. The user presses 
+     * the button, switches to a private chat with the bot and, in doing so, 
+     * passes a start parameter that instructs the bot to return an oauth link. 
+     * Once done, the bot can offer a switch_inline button so that the user can 
+     * easily return to the chat where they wanted to use the bot's inline capabilities.
+     * @see https://core.telegram.org/bots/api/bots#deep-linking
+     * @see https://core.telegram.org/bots/api#inlinekeyboardmarkup
+     */
+    switch_pm_parameter?: string,
   };
 
   /**
@@ -1835,15 +4527,13 @@ declare module "telegram-typings" {
     description?: string,
 
     /**
-     * Caption of the photo to be sent, 0-200 characters
+     * Caption of the photo to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the photo caption. See formatting options 
+     * for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -1898,9 +4588,15 @@ declare module "telegram-typings" {
     gif_duration?: number,
 
     /**
-     * URL of the static thumbnail for the result (jpeg or gif)
+     * URL of the static (JPEG or GIF) or animated (MPEG4) thumbnail for the result
      */
     thumb_url: string,
+
+    /**
+     * MIME type of the thumbnail, must be one of “image/jpeg”, “image/gif”, or 
+     * “video/mp4”. Defaults to “image/jpeg”
+     */
+    thumb_mime_type?: string,
 
     /**
      * Title for the result
@@ -1908,15 +4604,13 @@ declare module "telegram-typings" {
     title?: string,
 
     /**
-     * Caption of the GIF file to be sent, 0-200 characters
+     * Caption of the GIF file to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the caption. See formatting options for 
+     * more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -1971,9 +4665,15 @@ declare module "telegram-typings" {
     mpeg4_duration?: number,
 
     /**
-     * URL of the static thumbnail (jpeg or gif) for the result
+     * URL of the static (JPEG or GIF) or animated (MPEG4) thumbnail for the result
      */
     thumb_url: string,
+
+    /**
+     * MIME type of the thumbnail, must be one of “image/jpeg”, “image/gif”, or 
+     * “video/mp4”. Defaults to “image/jpeg”
+     */
+    thumb_mime_type?: string,
 
     /**
      * Title for the result
@@ -1981,15 +4681,13 @@ declare module "telegram-typings" {
     title?: string,
 
     /**
-     * Caption of the MPEG-4 file to be sent, 0-200 characters
+     * Caption of the MPEG-4 file to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the caption. See formatting options for 
+     * more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -2044,15 +4742,13 @@ declare module "telegram-typings" {
     title: string,
 
     /**
-     * Caption of the video to be sent, 0-200 characters
+     * Caption of the video to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the video caption. See formatting options 
+     * for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -2092,7 +4788,7 @@ declare module "telegram-typings" {
   };
 
   /**
-   * Represents a link to an mp3 audio file. By default, this audio file will 
+   * Represents a link to an MP3 audio file. By default, this audio file will 
    * be sent by the user. Alternatively, you can use input_message_content to 
    * send a message with the specified content instead of the audio.
    */
@@ -2118,15 +4814,13 @@ declare module "telegram-typings" {
     title: string,
 
     /**
-     * Caption, 0-200 characters
+     * Caption, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the audio caption. See formatting options 
+     * for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -2154,7 +4848,7 @@ declare module "telegram-typings" {
   };
 
   /**
-   * Represents a link to a voice recording in an .ogg container encoded with 
+   * Represents a link to a voice recording in an .OGG container encoded with 
    * OPUS. By default, this voice recording will be sent by the user. 
    * Alternatively, you can use input_message_content to send a message with 
    * the specified content instead of the the voice message.
@@ -2181,15 +4875,13 @@ declare module "telegram-typings" {
     title: string,
 
     /**
-     * Caption, 0-200 characters
+     * Caption, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the voice message caption. See formatting 
+     * options for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -2235,15 +4927,13 @@ declare module "telegram-typings" {
     title: string,
 
     /**
-     * Caption of the document to be sent, 0-200 characters
+     * Caption of the document to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the document caption. See formatting 
+     * options for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -2551,15 +5241,13 @@ declare module "telegram-typings" {
     description?: string,
 
     /**
-     * Caption of the photo to be sent, 0-200 characters
+     * Caption of the photo to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the photo caption. See formatting options 
+     * for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -2605,15 +5293,13 @@ declare module "telegram-typings" {
     title?: string,
 
     /**
-     * Caption of the GIF file to be sent, 0-200 characters
+     * Caption of the GIF file to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the caption. See formatting options for 
+     * more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -2659,15 +5345,13 @@ declare module "telegram-typings" {
     title?: string,
 
     /**
-     * Caption of the MPEG-4 file to be sent, 0-200 characters
+     * Caption of the MPEG-4 file to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the caption. See formatting options for 
+     * more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -2751,15 +5435,13 @@ declare module "telegram-typings" {
     description?: string,
 
     /**
-     * Caption of the document to be sent, 0-200 characters
+     * Caption of the document to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the document caption. See formatting 
+     * options for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -2809,15 +5491,13 @@ declare module "telegram-typings" {
     description?: string,
 
     /**
-     * Caption of the video to be sent, 0-200 characters
+     * Caption of the video to be sent, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the video caption. See formatting options 
+     * for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -2862,15 +5542,13 @@ declare module "telegram-typings" {
     title: string,
 
     /**
-     * Caption, 0-200 characters
+     * Caption, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the voice message caption. See formatting 
+     * options for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -2888,7 +5566,7 @@ declare module "telegram-typings" {
   };
 
   /**
-   * Represents a link to an mp3 audio file stored on the Telegram servers. 
+   * Represents a link to an MP3 audio file stored on the Telegram servers. 
    * By default, this audio file will be sent by the user. Alternatively, you 
    * can use input_message_content to send a message with the specified 
    * content instead of the audio.
@@ -2910,15 +5588,13 @@ declare module "telegram-typings" {
     audio_file_id: string,
 
     /**
-     * Caption, 0-200 characters
+     * Caption, 0-1024 characters after entities parsing
      */
     caption?: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in the media caption.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the audio caption. See formatting options 
+     * for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -2947,10 +5623,8 @@ declare module "telegram-typings" {
     message_text: string,
 
     /**
-     * Send Markdown or HTML, if you want Telegram apps to show bold, italic, 
-     * fixed-width text or inline URLs in your bot's message.
-     * @see https://core.telegram.org/bots/api#markdown-style
-     * @see https://core.telegram.org/bots/api#html-style
+     * Mode for parsing entities in the message text. See formatting options 
+     * for more details.
      * @see https://core.telegram.org/bots/api#formatting-options
      */
     parse_mode?: string,
@@ -3085,6 +5759,204 @@ declare module "telegram-typings" {
      * The query that was used to obtain the result
      */
     query: string,
+  };
+
+  /**
+   * Use this method to send invoices. On success, the sent Message is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendInvoicePayload = {
+    /**
+     * Unique identifier for the target private chat
+     */
+    chat_id: number,
+
+    /**
+     * Product name, 1-32 characters
+     */
+    title: string,
+
+    /**
+     * Product description, 1-255 characters
+     */
+    description: string,
+
+    /**
+     * Bot-defined invoice payload, 1-128 bytes. This will not be displayed to 
+     * the user, use for your internal processes.
+     */
+    payload: string,
+
+    /**
+     * Payments provider token, obtained via Botfather
+     * @see https://t.me/botfather
+     */
+    provider_token: string,
+
+    /**
+     * Unique deep-linking parameter that can be used to generate this invoice 
+     * when used as a start parameter
+     */
+    start_parameter: string,
+
+    /**
+     * Three-letter ISO 4217 currency code, see more on currencies
+     * @see https://core.telegram.org/bots/api/bots/payments#supported-currencies
+     */
+    currency: string,
+
+    /**
+     * Price breakdown, a JSON-serialized list of components (e.g. product 
+     * price, tax, discount, delivery cost, delivery tax, bonus, etc.)
+     */
+    prices: LabeledPrice[],
+
+    /**
+     * A JSON-serialized data about the invoice, which will be shared with the 
+     * payment provider. A detailed description of required fields should be 
+     * provided by the payment provider.
+     */
+    provider_data?: string,
+
+    /**
+     * URL of the product photo for the invoice. Can be a photo of the goods or 
+     * a marketing image for a service. People like it better when they see 
+     * what they are paying for.
+     */
+    photo_url?: string,
+
+    /**
+     * Photo size
+     */
+    photo_size?: number,
+
+    /**
+     * Photo width
+     */
+    photo_width?: number,
+
+    /**
+     * Photo height
+     */
+    photo_height?: number,
+
+    /**
+     * Pass True, if you require the user's full name to complete the order
+     */
+    need_name?: boolean,
+
+    /**
+     * Pass True, if you require the user's phone number to complete the order
+     */
+    need_phone_number?: boolean,
+
+    /**
+     * Pass True, if you require the user's email address to complete the order
+     */
+    need_email?: boolean,
+
+    /**
+     * Pass True, if you require the user's shipping address to complete the order
+     */
+    need_shipping_address?: boolean,
+
+    /**
+     * Pass True, if user's phone number should be sent to provider
+     */
+    send_phone_number_to_provider?: boolean,
+
+    /**
+     * Pass True, if user's email address should be sent to provider
+     */
+    send_email_to_provider?: boolean,
+
+    /**
+     * Pass True, if the final price depends on the shipping method
+     */
+    is_flexible?: boolean,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * A JSON-serialized object for an inline keyboard. If empty, one 'Pay 
+     * total price' button will be shown. If not empty, the first button must 
+     * be a Pay button.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     */
+    reply_markup?: InlineKeyboardMarkup,
+  };
+
+  /**
+   * If you sent an invoice requesting a shipping address and the parameter 
+   * is_flexible was specified, the Bot API will send an Update with a 
+   * shipping_query field to the bot. Use this method to reply to shipping 
+   * queries. On success, True is returned.
+   * @see https://core.telegram.org/bots/api#update
+   */
+  declare type AnswerShippingQueryPayload = {
+    /**
+     * Unique identifier for the query to be answered
+     */
+    shipping_query_id: string,
+
+    /**
+     * Specify True if delivery to the specified address is possible and False 
+     * if there are any problems (for example, if delivery to the specified 
+     * address is not possible)
+     */
+    ok: boolean,
+
+    /**
+     * Required if ok is True. A JSON-serialized array of available shipping options.
+     */
+    shipping_options?: ShippingOption[],
+
+    /**
+     * Required if ok is False. Error message in human readable form that 
+     * explains why it is impossible to complete the order (e.g. "Sorry, 
+     * delivery to your desired address is unavailable'). Telegram will display 
+     * this message to the user.
+     */
+    error_message?: string,
+  };
+
+  /**
+   * Once the user has confirmed their payment and shipping details, the Bot 
+   * API sends the final confirmation in the form of an Update with the field 
+   * pre_checkout_query. Use this method to respond to such pre-checkout 
+   * queries. On success, True is returned. Note: The Bot API must receive an 
+   * answer within 10 seconds after the pre-checkout query was sent.
+   * @see https://core.telegram.org/bots/api#update
+   */
+  declare type AnswerPreCheckoutQueryPayload = {
+    /**
+     * Unique identifier for the query to be answered
+     */
+    pre_checkout_query_id: string,
+
+    /**
+     * Specify True if everything is alright (goods are available, etc.) and 
+     * the bot is ready to proceed with the order. Use False if there are any problems.
+     */
+    ok: boolean,
+
+    /**
+     * Required if ok is False. Error message in human readable form that 
+     * explains the reason for failure to proceed with the checkout (e.g. 
+     * "Sorry, somebody just bought the last of our amazing black T-shirts 
+     * while you were busy filling out your payment details. Please choose a 
+     * different color or garment!"). Telegram will display this message to the user.
+     */
+    error_message?: string,
   };
 
   /**
@@ -3344,9 +6216,15 @@ declare module "telegram-typings" {
    */
   declare type PassportFile = {
     /**
-     * Unique identifier for this file
+     * Identifier for this file, which can be used to download or reuse the file
      */
     file_id: string,
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over 
+     * time and for different bots. Can't be used to download or reuse the file.
+     */
+    file_unique_id: string,
 
     /**
      * File size
@@ -3357,6 +6235,24 @@ declare module "telegram-typings" {
      * Unix time when the file was uploaded
      */
     file_date: number,
+  };
+
+  /**
+   * Informs a user that some of the Telegram Passport elements they provided 
+   * contains errors. The user will not be able to re-submit their Passport 
+   * to you until the errors are fixed (the contents of the field for which 
+   * you returned the error must change). Returns True on success.
+   */
+  declare type SetPassportDataErrorsPayload = {
+    /**
+     * User identifier
+     */
+    user_id: number,
+
+    /**
+     * A JSON-serialized array describing the errors
+     */
+    errors: PassportElementError[],
   };
 
   /**
@@ -3530,6 +6426,128 @@ declare module "telegram-typings" {
   };
 
   /**
+   * Represents an issue with one of the files that constitute the 
+   * translation of a document. The error is considered resolved when the 
+   * file changes.
+   */
+  declare type PassportElementErrorTranslationFile = {
+    /**
+     * Error source, must be translation_file
+     */
+    source: string,
+
+    /**
+     * Type of element of the user's Telegram Passport which has the issue, one 
+     * of “passport”, “driver_license”, “identity_card”, “internal_passport”, 
+     * “utility_bill”, “bank_statement”, “rental_agreement”, 
+     * “passport_registration”, “temporary_registration”
+     */
+    type: string,
+
+    /**
+     * Base64-encoded file hash
+     */
+    file_hash: string,
+
+    /**
+     * Error message
+     */
+    message: string,
+  };
+
+  /**
+   * Represents an issue with the translated version of a document. The error 
+   * is considered resolved when a file with the document translation change.
+   */
+  declare type PassportElementErrorTranslationFiles = {
+    /**
+     * Error source, must be translation_files
+     */
+    source: string,
+
+    /**
+     * Type of element of the user's Telegram Passport which has the issue, one 
+     * of “passport”, “driver_license”, “identity_card”, “internal_passport”, 
+     * “utility_bill”, “bank_statement”, “rental_agreement”, 
+     * “passport_registration”, “temporary_registration”
+     */
+    type: string,
+
+    /**
+     * List of base64-encoded file hashes
+     */
+    file_hashes: string[],
+
+    /**
+     * Error message
+     */
+    message: string,
+  };
+
+  /**
+   * Represents an issue in an unspecified place. The error is considered 
+   * resolved when new data is added.
+   */
+  declare type PassportElementErrorUnspecified = {
+    /**
+     * Error source, must be unspecified
+     */
+    source: string,
+
+    /**
+     * Type of element of the user's Telegram Passport which has the issue
+     */
+    type: string,
+
+    /**
+     * Base64-encoded element hash
+     */
+    element_hash: string,
+
+    /**
+     * Error message
+     */
+    message: string,
+  };
+
+  /**
+   * Use this method to send a game. On success, the sent Message is returned.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SendGamePayload = {
+    /**
+     * Unique identifier for the target chat
+     */
+    chat_id: number,
+
+    /**
+     * Short name of the game, serves as the unique identifier for the game. 
+     * Set up your games via Botfather.
+     * @see https://t.me/botfather
+     */
+    game_short_name: string,
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @see https://telegram.org/blog/channels-2-0#silent-messages
+     */
+    disable_notification?: boolean,
+
+    /**
+     * If the message is a reply, ID of the original message
+     */
+    reply_to_message_id?: number,
+
+    /**
+     * A JSON-serialized object for an inline keyboard. If empty, one 'Play 
+     * game_title' button will be shown. If not empty, the first button must 
+     * launch the game.
+     * @see https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating
+     */
+    reply_markup?: InlineKeyboardMarkup,
+  };
+
+  /**
    * This object represents a game. Use BotFather to create and edit games, 
    * their short names will act as unique identifiers.
    */
@@ -3571,6 +6589,84 @@ declare module "telegram-typings" {
      * @see https://t.me/botfather
      */
     animation?: Animation,
+  };
+
+  /**
+   * Use this method to set the score of the specified user in a game. On 
+   * success, if the message was sent by the bot, returns the edited Message, 
+   * otherwise returns True. Returns an error, if the new score is not 
+   * greater than the user's current score in the chat and force is False.
+   * @see https://core.telegram.org/bots/api#message
+   */
+  declare type SetGameScorePayload = {
+    /**
+     * User identifier
+     */
+    user_id: number,
+
+    /**
+     * New score, must be non-negative
+     */
+    score: number,
+
+    /**
+     * Pass True, if the high score is allowed to decrease. This can be useful 
+     * when fixing mistakes or banning cheaters
+     */
+    force?: boolean,
+
+    /**
+     * Pass True, if the game message should not be automatically edited to 
+     * include the current scoreboard
+     */
+    disable_edit_message?: boolean,
+
+    /**
+     * Required if inline_message_id is not specified. Unique identifier for 
+     * the target chat
+     */
+    chat_id?: number,
+
+    /**
+     * Required if inline_message_id is not specified. Identifier of the sent message
+     */
+    message_id?: number,
+
+    /**
+     * Required if chat_id and message_id are not specified. Identifier of the 
+     * inline message
+     */
+    inline_message_id?: string,
+  };
+
+  /**
+   * Use this method to get data for high score tables. Will return the score 
+   * of the specified user and several of their neighbors in a game. On 
+   * success, returns an Array of GameHighScore objects.
+   * @see https://core.telegram.org/bots/api#gamehighscore
+   */
+  declare type GetGameHighScoresPayload = {
+    /**
+     * Target user id
+     */
+    user_id: number,
+
+    /**
+     * Required if inline_message_id is not specified. Unique identifier for 
+     * the target chat
+     */
+    chat_id?: number,
+
+    /**
+     * Required if inline_message_id is not specified. Identifier of the sent message
+     */
+    message_id?: number,
+
+    /**
+     * Required if chat_id and message_id are not specified. Identifier of the 
+     * inline message
+     */
+    inline_message_id?: string,
   };
 
   /**

--- a/lib/builders/base.js
+++ b/lib/builders/base.js
@@ -58,7 +58,7 @@ class BaseBuilder {
    * Wraps a type with the AST union node
    */
   // eslint-disable-next-line no-unused-vars
-  buildUnionOfTypesFromLiteral(types/*: Array<string> */, separator/*: string */) {
+  buildUnionOfTypesFromLiteral(types/*: string */, separator/*: string */) {
     throw new TypeError('The `buildUnionOfTypesFromLiteral` method should be overriden')
   }
 
@@ -125,7 +125,10 @@ class BaseBuilder {
         }
 
         if (object instanceof Union) {
-          const callbackfn = (name) => !this.store.get(object.name).variants.includes(name)
+          const type = this.store.get(object.name) || { variants: [] }
+
+          // $FlowDisable
+          const callbackfn = (name) => !type.variants.includes(name)
           const unknown = object.variants.filter(callbackfn)
 
           if (unknown.length > 0) {

--- a/lib/builders/base.js
+++ b/lib/builders/base.js
@@ -2,6 +2,8 @@ const { Interface, Method, Union /*::, Store, */ } = require('../store')
 
 
 const ARRAY_OF_LITERAL = 'Array of '
+const INTERSECTION_LITERAL = ' and'
+const UNION_LITERAL = ' or'
 
 /**
  * Class for creating base types.
@@ -50,6 +52,14 @@ class BaseBuilder {
    */
   buildUnionOfTypes(types/*: Array<string> */) { // eslint-disable-line no-unused-vars
     throw new TypeError('The `buildUnionOfTypes` method should be overriden')
+  }
+
+  /**
+   * Wraps a type with the AST union node
+   */
+  // eslint-disable-next-line no-unused-vars
+  buildUnionOfTypesFromLiteral(types/*: Array<string> */, separator/*: string */) {
+    throw new TypeError('The `buildUnionOfTypesFromLiteral` method should be overriden')
   }
 
   /**
@@ -115,7 +125,8 @@ class BaseBuilder {
         }
 
         if (object instanceof Union) {
-          const unknown = object.variants.filter((name) => !this.store.has(name))
+          const callbackfn = (name) => !this.store.get(object.name).variants.includes(name)
+          const unknown = object.variants.filter(callbackfn)
 
           if (unknown.length > 0) {
             throw new TypeError(`${unknown.join(', ')} not found in the store`)
@@ -164,6 +175,14 @@ class BaseBuilder {
 
     if (name.indexOf(ARRAY_OF_LITERAL) === 0) {
       return this.buildArrayOfType(name)
+    }
+
+    if (name.includes(INTERSECTION_LITERAL)) {
+      return this.buildUnionOfTypesFromLiteral(name, INTERSECTION_LITERAL)
+    }
+
+    if (name.includes(UNION_LITERAL)) {
+      return this.buildUnionOfTypesFromLiteral(name, UNION_LITERAL)
     }
 
     const type = this.store.get(name)

--- a/lib/builders/flow.js
+++ b/lib/builders/flow.js
@@ -25,6 +25,12 @@ class FlowBuilder extends AbstractJsBuilder {
     return bt.unionTypeAnnotation(types.map((name) => this.buildNativeType(name)))
   }
 
+  buildUnionOfTypesFromLiteral(types/*: string*/, separator/*: string*/) {
+    const reduced = types.split(separator).reduce((r, v) => [...r, v.trim()], [])
+
+    return bt.arrayTypeAnnotation(this.buildNativeType(reduced))
+  }
+
   buildInterface(object/*: Interface*/) {
     const fields = Object.keys(object.fields)
       .map((fieldName) => this.buildField(object.fields[fieldName]))
@@ -83,7 +89,7 @@ class FlowBuilder extends AbstractJsBuilder {
   }
 
   buildBooleanLiteral(value/*: boolean*/) {
-    const ast = bt.booleanLiteralTypeAnnotation()
+    const ast = bt.booleanLiteralTypeAnnotation(false)
 
     ast.value = value
 

--- a/lib/builders/typescript.js
+++ b/lib/builders/typescript.js
@@ -27,7 +27,13 @@ class TypeScriptBuilder extends AbstractJsBuilder {
     // TODO: Build unions with AST builders, not raw strings.
     // The architecture between Flow builder and TypeScript builder differs, and we need
     // to return a `string` type instead of an AST node from this method
-    return types.map((type) => this.buildNativeType(type)).join(' | ')
+    const map = types.map((type) => this.buildNativeType(type)).join(' | ')
+
+    return types.length > 1 ? `(${map})` : map
+  }
+
+  buildUnionOfTypesFromLiteral(types/*: string*/, separator/*: string*/) {
+    return this.buildNativeType(types.split(separator).reduce((r, v) => [...r, v.trim()], []))
   }
 
   buildInterface(object/*: Interface*/) {
@@ -48,7 +54,22 @@ class TypeScriptBuilder extends AbstractJsBuilder {
     return ast
   }
 
-  buildMethod(object/*: Method*/) { // eslint-disable-line no-unused-vars
+  buildMethod(object /*: Method*/) {
+    const fields = Object.keys(object.fields)
+      .map((fieldName) => this.buildField(object.fields[fieldName]))
+    const ast = bt.exportNamedDeclaration(
+      bt.tsInterfaceDeclaration(
+        bt.identifier(object.name),
+        undefined,
+        null,
+        bt.tsInterfaceBody(fields),
+      ),
+      []
+    )
+
+    ast.leadingComments = this.buildComments(object.description || '', object.links)
+
+    return ast
   }
 
   buildField(object/*: Field*/) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,24 +38,21 @@ function addBuiltins(store) {
   }))
   store.add(new Interface('InputFile', {
     description: 'This object represents the contents of a file to be uploaded. '
-                  + 'Must be posted using multipart/form-data in the usual way that files are uploaded via the browser.',
+      + 'Must be posted using multipart/form-data in the usual way that files are uploaded via the browser.',
   }))
-  store.add(new Interface(
-    'PassportData', {
-      description: 'Contains information about Telegram Passport data shared with the bot by the user.',
-    },
-    {
-      data: new Field('data', 'Array of EncryptedPassportElement'),
-      credentials: new Field('credentials', 'EncryptedCredentials'),
-    }
-  ))
+  store.add(new Interface('PassportData', {
+    description: 'Contains information about Telegram Passport data shared with the bot by the user.',
+  }, {
+    data: new Field('data', 'Array of EncryptedPassportElement'),
+    credentials: new Field('credentials', 'EncryptedCredentials'),
+  }))
   store.add(new Interface('EncryptedPassportElement', {
     desciption: 'Contains information about documents or other Telegram Passport elements shared with the bot by the user.',
   }))
   store.add(new Interface('EncryptedCredentials', {
     description: 'Contains data required for decrypting and authenticating EncryptedPassportElement.'
-    + ' See the Telegram Passport Documentation for a complete description of the data decryption'
-    + ' and authentication processes.',
+      + ' See the Telegram Passport Documentation for a complete description of the data decryption'
+      + ' and authentication processes.',
   }))
   // TODO: remove after parse UNIONS
   store.add(new Union('InputMessageContent', {
@@ -96,6 +93,19 @@ function addBuiltins(store) {
     'InlineQueryResultVideo',
     'InlineQueryResultVoice',
   ]))
+  store.add(new Union('PassportElementError', {
+    description: 'This object represents an error in the Telegram Passport element which was submitted that should be resolved by the user',
+  }, [
+    'PassportElementErrorDataField',
+    'PassportElementErrorFrontSide',
+    'PassportElementErrorReverseSide',
+    'PassportElementErrorSelfie',
+    'PassportElementErrorFile',
+    'PassportElementErrorFiles',
+    'PassportElementErrorTranslationFile',
+    'PassportElementErrorTranslationFiles',
+    'PassportElementErrorUnspecified',
+  ]))
 }
 
 async function main() {
@@ -108,7 +118,7 @@ async function main() {
 
   buildFlow(store)
   buildTypeScript(store)
-  buildRust(store)
+  // buildRust(store)
 }
 
 module.exports = main

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -106,7 +106,7 @@ async function handleInterface({ name, description, rows }) {
     const fieldName = flName.text().trim()
     let fieldType = flType.text().trim()
 
-    if (['Field', 'Parameters'].includes(fieldName)) {
+    if (['Field', 'Parameter'].includes(fieldName)) {
       continue // eslint-disable-line no-continue
     }
 
@@ -154,7 +154,9 @@ async function handleMethod({ name, description, rows }) {
     const fieldName = flName.text().trim()
     let fieldType = flType.text().trim()
 
-    if (['Field', 'Parameters'].includes(fieldName)) {
+    // fieldName = fieldName.charAt(0).toUpperCase() + fieldName.slice(1)
+
+    if (['Field', 'Parameter'].includes(fieldName)) {
       continue // eslint-disable-line no-continue
     }
 
@@ -177,8 +179,11 @@ async function handleMethod({ name, description, rows }) {
     fields[field.name] = field
   }
 
+  const trimmedName = name.text().trim()
+  const startCasedName = trimmedName.charAt(0).toUpperCase() + trimmedName.slice(1)
+
   const typeClass = new Method(
-    name.text().trim(),
+    startCasedName,
     { description: description.text().trim(), links: parseLinks(description) },
     fields
   )
@@ -201,11 +206,11 @@ async function requestAndParse(store/*: Store*/) {
   const list = await toArray(tables)
 
   for (const table of list) {
-    const type = table.find('tr:first-child td:first-child').text()
+    const type = table.find('thead tr:first-child th:first-child').text()
 
     let typeClass
 
-    if (!['Field', 'Parameters'].includes(type)) {
+    if (!['Field', 'Parameter'].includes(type)) {
       continue // eslint-disable-line no-continue
     }
 
@@ -217,14 +222,14 @@ async function requestAndParse(store/*: Store*/) {
       continue // eslint-disable-line no-continue
     }
 
-    const rows = await toArray(table.find('tr'))
+    const rows = await toArray(table.find('tbody tr'))
 
     if (type === 'Field') {
       typeClass = await handleInterface({ name, description, rows })
     }
-    // else if (type === 'Parameters') {
-    //   typeClass = await handleMethod({ name, description, rows })
-    // }
+    else if (type === 'Parameter') {
+      typeClass = await handleMethod({ name, description, rows })
+    }
 
     if (!typeClass) {
       continue // eslint-disable-line no-continue


### PR DESCRIPTION
I tried to keep the coding style as close as possibile to yours, eslint combined with flow was a total pain in the ass to deal with but it's your project so no big deal, but I don't think I'll ever want to deal with this codebase in the future since it was not so easy to work on.

The patch is far from perfect and I had to use a workaround that you'll probably will want to change to deal with the parameters of the method: **sendMediaGroup**

Its type has this semantic:

`Array of InputMediaPhoto and InputMediaVideo`

Which was not something you handled before, I implemented a method to handle both the 'and' and 'or' separators in the types, which is something that you already do with the 'or' but in the parser handlers so it's probably not needed there but I left it for good measure, though I wonder how you'd have handled it on the parser handlers since it also has the "Array of" which you handle later on the **buildNativeType** method.

I also had to deal with the fact that **sendMediaGroup** wants an array of those 2 types so I just applied some parenthesis on all multiple unions for typescript, flow is for some kind of reason getting 2 square brackets rather than 1 like on typescript but I didn't try to fix it, I'll leave it to you.

This is all, wish you well :D